### PR TITLE
YAML config support

### DIFF
--- a/Callisto.xcodeproj/project.pbxproj
+++ b/Callisto.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		CDF007092074FAC200257FCC /* ios_build_8731.log in Resources */ = {isa = PBXBuildFile; fileRef = CDF007072074FAC200257FCC /* ios_build_8731.log */; };
 		CDF0070E20760B1900257FCC /* ios_build_8745.log in Resources */ = {isa = PBXBuildFile; fileRef = CDF0070C20760B1900257FCC /* ios_build_8745.log */; };
 		CDF0070F20760B1900257FCC /* mac_build_8745.log in Resources */ = {isa = PBXBuildFile; fileRef = CDF0070D20760B1900257FCC /* mac_build_8745.log */; };
+		CDF2AD772706D03B00DED1A1 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = CDF2AD762706D03B00DED1A1 /* Yams */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -149,6 +150,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDF2AD772706D03B00DED1A1 /* Yams in Frameworks */,
 				CDAE77812705865A00651B95 /* ArgumentParser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -347,6 +349,7 @@
 			name = Callisto;
 			packageProductDependencies = (
 				CDAE77802705865A00651B95 /* ArgumentParser */,
+				CDF2AD762706D03B00DED1A1 /* Yams */,
 			);
 			productName = Callisto;
 			productReference = CD8BBDCA1EE0093900E8EE2E /* Callisto */;
@@ -386,6 +389,7 @@
 			mainGroup = CD8BBDC11EE0093900E8EE2E;
 			packageReferences = (
 				CDAE777F2705865A00651B95 /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
+				CDF2AD752706D03B00DED1A1 /* XCRemoteSwiftPackageReference "Yams" */,
 			);
 			productRefGroup = CD8BBDCB1EE0093900E8EE2E /* Products */;
 			projectDirPath = "";
@@ -716,6 +720,14 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		CDF2AD752706D03B00DED1A1 /* XCRemoteSwiftPackageReference "Yams" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/jpsim/Yams";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -723,6 +735,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = CDAE777F2705865A00651B95 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
 			productName = ArgumentParser;
+		};
+		CDF2AD762706D03B00DED1A1 /* Yams */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CDF2AD752706D03B00DED1A1 /* XCRemoteSwiftPackageReference "Yams" */;
+			productName = Yams;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Callisto.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Callisto.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "d2930e8fcf9c33162b9fcc1d522bc975e2d4179b",
           "version": "1.0.1"
         }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams",
+        "state": {
+          "branch": null,
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
+        }
       }
     ]
   },

--- a/Callisto/BuildInformation.swift
+++ b/Callisto/BuildInformation.swift
@@ -16,13 +16,13 @@ struct BuildInformation: Codable {
     let errors: [CompilerMessage]
     let warnings: [CompilerMessage]
     let unitTests: [UnitTestMessage]
-    let ignoredKeywords: [String]
+    let config: Config
 
     static let empty = BuildInformation(platform: "",
                                         errors: [],
                                         warnings: [],
                                         unitTests: [],
-                                        ignoredKeywords: [])
+                                        config: Config.empty)
 }
 
 extension BuildInformation {

--- a/Callisto/ExtractBuildInformationController.swift
+++ b/Callisto/ExtractBuildInformationController.swift
@@ -9,6 +9,20 @@
 import Foundation
 
 
+struct Config: Codable {
+    typealias File = String
+
+    struct Details: Codable {
+        let warnings: [String]?
+        let errors: [String]?
+        let tests: [String]?
+    }
+
+    let ignore: [File: Details]
+
+    static let empty = Config(ignore: [:])
+}
+
 /// Responsible to extract all build warnings & errors from fastlane
 /// output and save this information to a file
 final class ExtractBuildInformationController: NSObject {
@@ -18,7 +32,7 @@ final class ExtractBuildInformationController: NSObject {
     }
 
     private var parser: FastlaneParser
-    private var ignore: [String]
+    private var config: Config
 
     // MARK: - Properties
 
@@ -28,11 +42,11 @@ final class ExtractBuildInformationController: NSObject {
 
     // MARK: - Lifecycle
 
-    init(contentsOfFile url: URL, ignoredKeywords: [String]) throws {
-        let parser = try FastlaneParser(url: url, ignoredKeywords: ignoredKeywords)
+    init(contentsOfFile url: URL, config: Config) throws {
+        let parser = try FastlaneParser(url: url, config: config)
 
         self.parser = parser
-        self.ignore = ignoredKeywords
+        self.config = config
     }
 
     // MARK: - ExtractBuildInformationController

--- a/Callisto/GithubAction.swift
+++ b/Callisto/GithubAction.swift
@@ -144,13 +144,12 @@ private extension UploadAction {
         let commonErrors = infos[0].errors.filter { infos[1].errors.contains($0) }
         let commonWarnings = infos[0].warnings.filter { infos[1].warnings.contains($0) }
         let commonUnitTests = infos[0].unitTests.filter { infos[1].unitTests.contains($0) }
-        let allIgnoredKeywords = infos.flatMap { $0.ignoredKeywords }
 
         return BuildInformation(platform: "Core",
                                 errors: commonErrors,
                                 warnings: commonWarnings,
                                 unitTests: commonUnitTests,
-                                ignoredKeywords: allIgnoredKeywords)
+                                config: .empty)
     }
 
     func stripInfos(_ strip: BuildInformation?, from: [BuildInformation]) -> [BuildInformation] {
@@ -161,7 +160,7 @@ private extension UploadAction {
                              errors: info.errors.deleting(strip.errors),
                              warnings: info.warnings.deleting(strip.warnings),
                              unitTests: info.unitTests.deleting(strip.unitTests),
-                             ignoredKeywords: info.ignoredKeywords.deleting(strip.ignoredKeywords))
+                             config: .empty)
         }
     }
 

--- a/Callisto/GithubAction.swift
+++ b/Callisto/GithubAction.swift
@@ -15,10 +15,10 @@ final class Github: ParsableCommand {
 
     public static let configuration = CommandConfiguration(abstract: "Upload Build Summary to Github")
 
-    @Option(help: "Token to access github")
+    @Option(help: "Token to access Github")
     var githubToken: String
 
-    @Option(help: "Organisation Account Name in github")
+    @Option(help: "Organisation Account Name in Github")
     var githubOrganisation: String
 
     @Option(help: "Github Repository Name")

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -20,10 +20,10 @@ final class Slack: ParsableCommand {
     @Option(help: "URL access Slack", transform: { return URL(string: $0)! })
     var slackUrl: URL
 
-    @Option(help: "Token to access github")
+    @Option(help: "Personal Access Token for Github")
     var githubToken: String
 
-    @Option(help: "Organisation Account Name in github")
+    @Option(help: "Organisation Account Name in Github")
     var githubOrganisation: String
 
     @Option(help: "Github Repository Name")

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -23,7 +23,7 @@ final class Slack: ParsableCommand {
     @Option(help: "Your GitHub Access Token")
     var githubToken: String
 
-    @Option(help: "Organisation Account Name in Github")
+    @Option(help: "Your GitHub Organisation Account Name")
     var githubOrganisation: String
 
     @Option(help: "Github Repository Name")

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -102,14 +102,14 @@ private extension PostSlackAction {
     }
 
     func makeSlackMessage(for branch: Branch?, infos: [BuildInformation]) -> SlackMessage {
-        let ignoredKeywords = infos.flatMap { $0.ignoredKeywords }
+//        let ignoredKeywords = infos.flatMap { $0.ignoredKeywords }
         let message = SlackMessage()
 
         // Overview
         let overViewAttachment = SlackAttachment(type: .good)
         overViewAttachment.title = branch?.slackTitle ?? "Branch: \(self.slack.branch)"
         overViewAttachment.titleURL = branch?.url
-        overViewAttachment.footer = "Ignored: \(ignoredKeywords.joined(separator: ", "))"
+//        overViewAttachment.footer = "Ignored: \(ignoredKeywords.joined(separator: ", "))"
         message.add(attachment: overViewAttachment)
 
         // Errors

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -20,7 +20,7 @@ final class Slack: ParsableCommand {
     @Option(help: "URL access Slack", transform: { return URL(string: $0)! })
     var slackUrl: URL
 
-    @Option(help: "Personal Access Token for Github")
+    @Option(help: "Your GitHub Access Token")
     var githubToken: String
 
     @Option(help: "Organisation Account Name in Github")

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -102,14 +102,20 @@ private extension PostSlackAction {
     }
 
     func makeSlackMessage(for branch: Branch?, infos: [BuildInformation]) -> SlackMessage {
-//        let ignoredKeywords = infos.flatMap { $0.ignoredKeywords }
+        let ignoredKeywords = infos.flatMap {
+            [
+                $0.config.ignore.values.compactMap { $0.warnings},
+                $0.config.ignore.values.compactMap { $0.errors },
+                $0.config.ignore.values.compactMap { $0.tests }
+            ].flatMap { $0 }
+        }.flatMap { $0 }
         let message = SlackMessage()
 
         // Overview
         let overViewAttachment = SlackAttachment(type: .good)
         overViewAttachment.title = branch?.slackTitle ?? "Branch: \(self.slack.branch)"
         overViewAttachment.titleURL = branch?.url
-//        overViewAttachment.footer = "Ignored: \(ignoredKeywords.joined(separator: ", "))"
+        overViewAttachment.footer = "Ignored: \(ignoredKeywords.joined(separator: ", "))"
         message.add(attachment: overViewAttachment)
 
         // Errors

--- a/Callisto/SummariseAction.swift
+++ b/Callisto/SummariseAction.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ArgumentParser
+import Yams
 
 
 /// Handles all steps from parsing the fastlane output to saving it in a temporary location
@@ -23,13 +24,16 @@ final class Summarise: ParsableCommand {
     @Option(help: "Location for Output file", completion: .file(), transform: URL.init(fileURLWithPath:))
     var output: URL
 
-    @Argument(help: "Ignore Messages which contain keywords")
-    var ignore: [String] = []
+    @Option(help: "Fine grade configuration", completion: .file(), transform: URL.init(fileURLWithPath:))
+    var config: URL
 
     // MARK: - SummariseAction
 
     func run() throws {
-        let extractController = try ExtractBuildInformationController(contentsOfFile: self.fastlane, ignoredKeywords: self.ignore)
+        let decoder = YAMLDecoder()
+        let encodedYAML = try String(contentsOf: self.config)
+        let config = try decoder.decode(Config.self, from: encodedYAML)
+        let extractController = try ExtractBuildInformationController(contentsOfFile: self.fastlane, config: config)
 
         switch extractController.run() {
         case .success(let fastlaneStatusCode):
@@ -50,4 +54,3 @@ final class Summarise: ParsableCommand {
         }
     }
 }
-

--- a/Callisto/SummariseAction.swift
+++ b/Callisto/SummariseAction.swift
@@ -24,7 +24,7 @@ final class Summarise: ParsableCommand {
     @Option(help: "Location for Output file", completion: .file(), transform: URL.init(fileURLWithPath:))
     var output: URL
 
-    @Option(help: "Fine grade configuration", completion: .file(), transform: URL.init(fileURLWithPath:))
+    @Option(help: "YML file to exclude messages from specific files", completion: .file(), transform: URL.init(fileURLWithPath:))
     var config: URL
 
     // MARK: - SummariseAction

--- a/Callisto/SummariseAction.swift
+++ b/Callisto/SummariseAction.swift
@@ -24,7 +24,7 @@ final class Summarise: ParsableCommand {
     @Option(help: "Location for Output file", completion: .file(), transform: URL.init(fileURLWithPath:))
     var output: URL
 
-    @Option(help: "YML file to exclude messages from specific files", completion: .file(), transform: URL.init(fileURLWithPath:))
+    @Option(help: "YAML file to exclude messages from specific files", completion: .file(), transform: URL.init(fileURLWithPath:))
     var config: URL
 
     // MARK: - SummariseAction


### PR DESCRIPTION
### Description

Previously it was only possible to silence warnings based on keywords but not for specific files. Adding YAML Support fixes this issue. We specifically wanted to silence this warning but only in this one file so we don't overlook potential issues in the future. We consider this okay because our CI builds for the simulator but we tested this code on device during development.
<img width="668" alt="Bildschirmfoto 2021-10-01 um 08 55 01" src="https://user-images.githubusercontent.com/18739004/136078665-146f73d4-3dff-431b-a5e3-0865e332b61a.png">

### Tasks

- [x] Add YML Config support
- [x] Post silenced keywords to slack

### Infos For Reviewer

Keep in Mind that this will break existing integrations because the `ignoreKeywords` flag is now gone. I would therefore suggest to bump the version number to 2.0

Structure of config.yml file:

```yml
ignore:
  # Useful to silence SPM Warnings
  "SourcePackages/checkouts":
    warnings:
      - "deprecated"
      - "`@_functionBuilder` has been renamed to `@resultBuilder`"
  "BMAttributionManager.swift":
    warnings:
      - "Code after 'return' will never be executed"
    errors:
      - "Some error you like to silence"
    tests:
      - "Some tests that fail"
```