### PR TITLE
Dependencies Checker

### DIFF
--- a/Callisto.xcodeproj/project.pbxproj
+++ b/Callisto.xcodeproj/project.pbxproj
@@ -17,6 +17,14 @@
 		CD8BBDF01EE009C600E8EE2E /* SlackCommunicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDE01EE009C600E8EE2E /* SlackCommunicationController.swift */; };
 		CD8BBDF11EE009C600E8EE2E /* SlackField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDE11EE009C600E8EE2E /* SlackField.swift */; };
 		CD8BBDF21EE009C600E8EE2E /* SlackMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDE21EE009C600E8EE2E /* SlackMessage.swift */; };
+		CD8CA207274CD877007606C4 /* DependenciesAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA206274CD877007606C4 /* DependenciesAction.swift */; };
+		CD8CA22D274CD9A4007606C4 /* MarkdownKit in Frameworks */ = {isa = PBXBuildFile; productRef = CD8CA22C274CD9A4007606C4 /* MarkdownKit */; };
+		CD8CA233274CD9D2007606C4 /* PodDependencyParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA22F274CD9D1007606C4 /* PodDependencyParser.swift */; };
+		CD8CA234274CD9D2007606C4 /* Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA230274CD9D1007606C4 /* Dependency.swift */; };
+		CD8CA235274CD9D2007606C4 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA231274CD9D1007606C4 /* Version.swift */; };
+		CD8CA238274CDA0E007606C4 /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA237274CDA0E007606C4 /* SemanticVersion.swift */; };
+		CD8CA23A274CDB4D007606C4 /* DependencyInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA239274CDB4D007606C4 /* DependencyInformation.swift */; };
+		CD8CA23C274CE06A007606C4 /* SummaryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA23B274CE06A007606C4 /* SummaryFile.swift */; };
 		CD9DF11122FC16D300779F6F /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDDB1EE009C600E8EE2E /* main.swift */; };
 		CD9DF11222FC16D300779F6F /* SummariseAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4E0F6722F43DC500C31E08 /* SummariseAction.swift */; };
 		CD9DF11322FC16D300779F6F /* PostGithubAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4E0F6D22F4475A00C31E08 /* PostGithubAction.swift */; };
@@ -125,6 +133,14 @@
 		CD8BBDE11EE009C600E8EE2E /* SlackField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlackField.swift; sourceTree = "<group>"; };
 		CD8BBDE21EE009C600E8EE2E /* SlackMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlackMessage.swift; sourceTree = "<group>"; };
 		CD8BBDE31EE009C600E8EE2E /* URLSession+synchronousTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLSession+synchronousTask.swift"; sourceTree = "<group>"; };
+		CD8CA206274CD877007606C4 /* DependenciesAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependenciesAction.swift; sourceTree = "<group>"; };
+		CD8CA22A274CD971007606C4 /* MarkdownKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = MarkdownKit; path = Dependencies/MarkdownKit; sourceTree = "<group>"; };
+		CD8CA22F274CD9D1007606C4 /* PodDependencyParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PodDependencyParser.swift; sourceTree = "<group>"; };
+		CD8CA230274CD9D1007606C4 /* Dependency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dependency.swift; sourceTree = "<group>"; };
+		CD8CA231274CD9D1007606C4 /* Version.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		CD8CA237274CDA0E007606C4 /* SemanticVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticVersion.swift; sourceTree = "<group>"; };
+		CD8CA239274CDB4D007606C4 /* DependencyInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyInformation.swift; sourceTree = "<group>"; };
+		CD8CA23B274CE06A007606C4 /* SummaryFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryFile.swift; sourceTree = "<group>"; };
 		CD9DF10D22FC102800779F6F /* Annotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Annotation.swift; sourceTree = "<group>"; };
 		CD9DF10F22FC15AB00779F6F /* GithubModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubModelTests.swift; sourceTree = "<group>"; };
 		CD9DF3A622FC294E00779F6F /* Output.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Output.swift; sourceTree = "<group>"; };
@@ -151,6 +167,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CDF2AD772706D03B00DED1A1 /* Yams in Frameworks */,
+				CD8CA22D274CD9A4007606C4 /* MarkdownKit in Frameworks */,
 				CDAE77812705865A00651B95 /* ArgumentParser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -197,9 +214,11 @@
 		CD8BBDC11EE0093900E8EE2E = {
 			isa = PBXGroup;
 			children = (
+				CD8CA229274CD971007606C4 /* Packages */,
 				CD8BBDCC1EE0093900E8EE2E /* Callisto */,
 				CD8320FF1EE7DF640029DBE0 /* CallistoTest */,
 				CD8BBDCB1EE0093900E8EE2E /* Products */,
+				CD8CA22B274CD9A4007606C4 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -216,9 +235,11 @@
 			isa = PBXGroup;
 			children = (
 				CD8BBDDB1EE009C600E8EE2E /* main.swift */,
+				CD8CA206274CD877007606C4 /* DependenciesAction.swift */,
 				CD4E0F6722F43DC500C31E08 /* SummariseAction.swift */,
 				CD4E0F6D22F4475A00C31E08 /* PostGithubAction.swift */,
 				CDB5A97B251A722D00CC486F /* PostSlackAction.swift */,
+				CD8CA236274CD9F4007606C4 /* Model */,
 				CD8BBDFA1EE00A8E00E8EE2E /* Parser */,
 				CD8BBDF41EE00A2500E8EE2E /* Communication Controller */,
 				CD8BBDF91EE00A7B00E8EE2E /* Helper */,
@@ -298,6 +319,7 @@
 		CD8BBDFA1EE00A8E00E8EE2E /* Parser */ = {
 			isa = PBXGroup;
 			children = (
+				CD8CA22F274CD9D1007606C4 /* PodDependencyParser.swift */,
 				CD33AF6E22F0766E002EC27C /* ExtractBuildInformationController.swift */,
 				CD8BBDD81EE009C600E8EE2E /* FastlaneParser.swift */,
 				CD8BBDD51EE009C600E8EE2E /* CompilerMessage.swift */,
@@ -305,6 +327,33 @@
 				CD33AF7022F07DF9002EC27C /* BuildInformation.swift */,
 			);
 			name = Parser;
+			sourceTree = "<group>";
+		};
+		CD8CA229274CD971007606C4 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				CD8CA22A274CD971007606C4 /* MarkdownKit */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		CD8CA22B274CD9A4007606C4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CD8CA236274CD9F4007606C4 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				CD8CA239274CDB4D007606C4 /* DependencyInformation.swift */,
+				CD8CA230274CD9D1007606C4 /* Dependency.swift */,
+				CD8CA231274CD9D1007606C4 /* Version.swift */,
+				CD8CA237274CDA0E007606C4 /* SemanticVersion.swift */,
+				CD8CA23B274CE06A007606C4 /* SummaryFile.swift */,
+			);
+			name = Model;
 			sourceTree = "<group>";
 		};
 		CD9DF3AC22FD4A4300779F6F /* Markdown */ = {
@@ -350,6 +399,7 @@
 			packageProductDependencies = (
 				CDAE77802705865A00651B95 /* ArgumentParser */,
 				CDF2AD762706D03B00DED1A1 /* Yams */,
+				CD8CA22C274CD9A4007606C4 /* MarkdownKit */,
 			);
 			productName = Callisto;
 			productReference = CD8BBDCA1EE0093900E8EE2E /* Callisto */;
@@ -464,10 +514,13 @@
 				CD9DF11722FC16D300779F6F /* CompilerMessage.swift in Sources */,
 				CD9DF11D22FC16D300779F6F /* Branch.swift in Sources */,
 				CD9DF12522FC16D300779F6F /* Common.swift in Sources */,
+				CD8CA238274CDA0E007606C4 /* SemanticVersion.swift in Sources */,
 				CD9DF11322FC16D300779F6F /* PostGithubAction.swift in Sources */,
 				CD8BBDF01EE009C600E8EE2E /* SlackCommunicationController.swift in Sources */,
 				CD8BBDEE1EE009C600E8EE2E /* SlackAction.swift in Sources */,
+				CD8CA23A274CDB4D007606C4 /* DependencyInformation.swift in Sources */,
 				CD9DF11122FC16D300779F6F /* main.swift in Sources */,
+				CD8CA235274CD9D2007606C4 /* Version.swift in Sources */,
 				CD0E20DB230447E8001D9159 /* Collection+Sugar.swift in Sources */,
 				CD8BBDF11EE009C600E8EE2E /* SlackField.swift in Sources */,
 				CD9DF11822FC16D300779F6F /* UnitTestMessage.swift in Sources */,
@@ -479,16 +532,20 @@
 				CD9DF11C22FC16D300779F6F /* GithubRepository.swift in Sources */,
 				CD8BBDEF1EE009C600E8EE2E /* SlackAttachment.swift in Sources */,
 				CD9DF11422FC16D300779F6F /* ExtractBuildInformationController.swift in Sources */,
+				CD8CA23C274CE06A007606C4 /* SummaryFile.swift in Sources */,
 				CD9DF11622FC16D300779F6F /* FastlaneParser.swift in Sources */,
 				CD9DF3AB22FC4AEF00779F6F /* Comment.swift in Sources */,
+				CD8CA233274CD9D2007606C4 /* PodDependencyParser.swift in Sources */,
 				CD9DF11F22FC16D300779F6F /* URLSession+synchronousTask.swift in Sources */,
 				CD9DF11922FC16D300779F6F /* BuildInformation.swift in Sources */,
+				CD8CA234274CD9D2007606C4 /* Dependency.swift in Sources */,
 				CD9DF12222FC16D300779F6F /* Dictionary+Optional.swift in Sources */,
 				CD8BBDF21EE009C600E8EE2E /* SlackMessage.swift in Sources */,
 				CD9DF11222FC16D300779F6F /* SummariseAction.swift in Sources */,
 				CD9DF12322FC16D300779F6F /* NSColor+NSColorHexadecimalValue.swift in Sources */,
 				CD9DF11B22FC16D300779F6F /* GithubAccess.swift in Sources */,
 				CD9DF11A22FC16D300779F6F /* GitHubCommunicationController.swift in Sources */,
+				CD8CA207274CD877007606C4 /* DependenciesAction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -731,6 +788,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		CD8CA22C274CD9A4007606C4 /* MarkdownKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MarkdownKit;
+		};
 		CDAE77802705865A00651B95 /* ArgumentParser */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = CDAE777F2705865A00651B95 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;

--- a/Callisto/BuildInformation.swift
+++ b/Callisto/BuildInformation.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import MarkdownKit
 
 
 /// Holds all information about a compiler run
@@ -44,6 +45,17 @@ extension BuildInformation {
             }
         }
         return "### \(self.platform) - \(descriptionCount(of: self.warnings)) warnings, \(descriptionCount(of: self.errors)) errors"
+    }
+
+    var githubSummaryText: Title {
+        func descriptionCount(of array: [AnyHashable]) -> String {
+            if array.isEmpty {
+                return "no"
+            } else {
+                return "\(array.count)"
+            }
+        }
+        return Title("\(self.platform) - \(descriptionCount(of: self.warnings)) warnings, \(descriptionCount(of: self.errors)) errors", header: .h3)
     }
 
     func write(to url: URL) -> Result<Int, Error> {

--- a/Callisto/Collection+Sugar.swift
+++ b/Callisto/Collection+Sugar.swift
@@ -52,3 +52,10 @@ extension Array where Element: Hashable {
         return Array(thisSet.symmetricDifference(otherSet))
     }
 }
+
+extension Sequence where Element: Hashable {
+    func uniqued() -> [Element] {
+        var set = Set<Element>()
+        return filter { set.insert($0).inserted }
+    }
+}

--- a/Callisto/Collection+Sugar.swift
+++ b/Callisto/Collection+Sugar.swift
@@ -43,3 +43,12 @@ extension Array where Element: Equatable {
         return array
     }
 }
+
+extension Array where Element: Hashable {
+
+    func difference(from other: [Element]) -> [Element] {
+        let thisSet = Set(self)
+        let otherSet = Set(other)
+        return Array(thisSet.symmetricDifference(otherSet))
+    }
+}

--- a/Callisto/CompilerMessage.swift
+++ b/Callisto/CompilerMessage.swift
@@ -78,7 +78,7 @@ fileprivate extension CompilerMessage {
         do {
             try regex = NSRegularExpression(pattern: pattern, options: .caseInsensitive)
         } catch {
-            print("error: could not create Regex")
+            LogError("error: could not create Regex")
             return nil
         }
 

--- a/Callisto/CompilerMessage.swift
+++ b/Callisto/CompilerMessage.swift
@@ -19,11 +19,15 @@ class CompilerMessage: Codable {
     // MARK: Lifecycle
 
     init?(message: String) {
-        guard let slashRange = message.range(of: "/") else { return nil }
+        guard let slashRange = message.range(of: "/") else {
+            return nil
+        }
 
         let validMessage = message[slashRange.lowerBound...]
         let components = validMessage.components(separatedBy: ":")
-        guard components.count >= 4 else { return nil }
+        guard components.count >= 4 else {
+            return nil
+        }
 
         let path = components[0]
         let line = components[1]
@@ -47,18 +51,22 @@ extension CompilerMessage: CustomStringConvertible {
 
 extension CompilerMessage: Hashable {
 
-    static func == (left: CompilerMessage, right: CompilerMessage) -> Bool {
-        return
-            left.file == right.file &&
-            left.line == right.line &&
-            left.column == right.column &&
-            left.message == right.message
-    }
-
     func hash(into hasher: inout Hasher) {
         hasher.combine(self.file)
         hasher.combine(self.line)
         hasher.combine(self.message)
+    }
+}
+
+extension CompilerMessage: Equatable {
+
+    static func == (left: CompilerMessage, right: CompilerMessage) -> Bool {
+        return (
+            left.file == right.file &&
+            left.line == right.line &&
+            left.column == right.column &&
+            left.message == right.message
+        )
     }
 }
 

--- a/Callisto/DependenciesAction.swift
+++ b/Callisto/DependenciesAction.swift
@@ -30,13 +30,19 @@ final class Dependencies: ParsableCommand {
 
     func run() throws {
         let output = self.shell("pod outdated", currentDirectoryURL: self.project)
+        print(">>> pod outdated ...")
+        print(output)
         let dependencies = PodDependencyParser.parse(content: output)
 
         let filtered = PodDependencyParser.filter(dependencies: dependencies, with: self.ignore)
         let ignored = filtered.difference(from: dependencies)
 
+        print("Outdated Pods: \(filtered)")
+
         let info = DependencyInformation(outdated: filtered, ignored: ignored)
         let summary = SummaryFile.dependencies(info)
+
+        print("Writing to file ...")
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]

--- a/Callisto/DependenciesAction.swift
+++ b/Callisto/DependenciesAction.swift
@@ -1,0 +1,107 @@
+//
+//  DependenciesAction.swift
+//  Callisto
+//
+//  Created by Patrick Kladek on 23.11.21.
+//  Copyright © 2021 IdeasOnCanvas. All rights reserved.
+//
+
+import Foundation
+import ArgumentParser
+import MarkdownKit
+
+
+/// Handles all steps from parsing the fastlane output to saving it in a temporary location
+final class Dependencies: ParsableCommand {
+
+    @Option(help: "Location of Project Folder", completion: .file(), transform: URL.init(fileURLWithPath:))
+    var project: URL
+
+    @Option(help: "Summary file is written to location", completion: .file(), transform: URL.init(fileURLWithPath:))
+    var output: URL
+
+    @Option(help: "Ignored Dependencies", transform: { string in
+        string.components(separatedBy: " ")
+    })
+    var ignore: [String] = []
+
+    @Flag(help: "When set exits with non zero status code which in turn will fail build pipeline")
+    var failPipeline: Bool = false
+
+    func run() throws {
+        let output = self.shell("pod outdated", currentDirectoryURL: self.project)
+        let dependencies = PodDependencyParser.parse(content: output)
+
+        let filtered = PodDependencyParser.filter(dependencies: dependencies, with: self.ignore)
+        let ignored = filtered.difference(from: dependencies)
+
+        let info = DependencyInformation(outdated: filtered, ignored: ignored)
+        let summary = SummaryFile.dependencies(info)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        let data = try encoder.encode(summary)
+
+        try data.write(to: self.output)
+
+        if self.failPipeline && filtered.hasElements {
+            throw ExitCode(1)
+        }
+    }
+}
+
+// MARK: - Private
+
+private extension Dependencies {
+
+    func shell(_ command: String, currentDirectoryURL: URL? = nil) -> String {
+        let task = Process()
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        let environment = [
+            "LANG": "en_US.UTF-8",
+            "PATH": [
+                "/usr/local/bin",
+                "/usr/bin",
+                "/bin",
+                "/usr/sbin",
+                "/sbin",
+            ].joined(separator: ":")
+        ]
+
+        task.standardOutput = outputPipe
+        task.standardError = errorPipe
+        task.arguments = ["-c", command]
+        task.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        task.environment = environment
+        task.currentDirectoryURL = currentDirectoryURL
+        task.launch()
+
+        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)!
+
+        return output
+    }
+
+    func makeOutdatedDocument(from dependencies: [Dependency]) -> Document {
+        var doc = Document()
+        doc.addComponent(Title("New Version Available", header: .h3))
+        doc.addComponent(EmptyLine())
+
+        var table = Table(titles: Table.Row(columns: ["Library", "Current", "New"]))
+        let rows = dependencies.map { Table.Row(columns: [$0.name, $0.currentVersion.description, $0.upgradeableVersion.description]) }
+        table.addRows(rows)
+        doc.addComponent(table)
+
+        doc.addComponent(EmptyLine())
+        doc.addComponent(Text("Update Version in Pofile and then run `pod update`"))
+
+        return doc
+    }
+
+    func makeUpdatedDocument() -> Document {
+        var doc = Document()
+        doc.addComponent(Title("All Dependencies up-to-date 👍", header: .h3))
+        return doc
+    }
+}

--- a/Callisto/DependenciesAction.swift
+++ b/Callisto/DependenciesAction.swift
@@ -30,25 +30,25 @@ final class Dependencies: ParsableCommand {
 
     func run() throws {
         let output = self.shell("pod outdated", currentDirectoryURL: self.project)
-        print(">>> pod outdated ...")
+        LogMessage("$ pod outdated")
         print(output)
         let dependencies = PodDependencyParser.parse(content: output)
 
         let filtered = PodDependencyParser.filter(dependencies: dependencies, with: self.ignore)
         let ignored = filtered.difference(from: dependencies)
 
-        print("Outdated Pods: \(filtered)")
+        LogMessage("Outdated Pods: \(filtered)")
 
         let info = DependencyInformation(outdated: filtered, ignored: ignored)
         let summary = SummaryFile.dependencies(info)
-
-        print("Writing to file ...")
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
         let data = try encoder.encode(summary)
 
         try data.write(to: self.output)
+
+        LogMessage("Summary written to: \(self.output.absoluteString)")
 
         if self.failPipeline && filtered.hasElements {
             throw ExitCode(1)

--- a/Callisto/Dependency.swift
+++ b/Callisto/Dependency.swift
@@ -1,0 +1,29 @@
+//
+//  Dependency.swift
+//  ci-dependencies-check
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import Foundation
+import MarkdownKit
+
+struct Dependency {
+    let name: String
+    let currentVersion: Version
+    let lockedVersion: Version
+    let upgradeableVersion: Version
+}
+
+extension Dependency: CustomStringConvertible {
+
+    var description: String {
+        return "\(self.name) \(self.currentVersion)"
+    }
+}
+
+extension Dependency: Equatable { }
+
+extension Dependency: Codable { }
+
+extension Dependency: Hashable { }

--- a/Callisto/DependencyInformation.swift
+++ b/Callisto/DependencyInformation.swift
@@ -1,0 +1,15 @@
+//
+//  DependencyInformation.swift
+//  Callisto
+//
+//  Created by Patrick Kladek on 23.11.21.
+//  Copyright © 2021 IdeasOnCanvas. All rights reserved.
+//
+
+import Foundation
+
+struct DependencyInformation: Codable {
+
+    let outdated: [Dependency]
+    let ignored: [Dependency]
+}

--- a/Callisto/ExtractBuildInformationController.swift
+++ b/Callisto/ExtractBuildInformationController.swift
@@ -57,10 +57,11 @@ final class ExtractBuildInformationController: NSObject {
     }
 
     func save(to url: URL) -> Result<Int, Error> {
-        let buildSummary = self.parser.buildSummary
+        let buildInformation = self.parser.buildSummary
+        let summary = SummaryFile.build(buildInformation)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        guard let data = try? encoder.encode(buildSummary) else { return .failure(ExtractError.encodingError)}
+        guard let data = try? encoder.encode(summary) else { return .failure(ExtractError.encodingError)}
 
         do {
             try FileManager().createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true, attributes: nil)

--- a/Callisto/FastlaneParser.swift
+++ b/Callisto/FastlaneParser.swift
@@ -175,11 +175,14 @@ private extension FastlaneParser {
     }
 
     func compilerMessages(from: [String]) -> [CompilerMessage] {
-        let filteredLines = Set(from.compactMap { line -> CompilerMessage? in
+//        let filteredLines = Set(from.compactMap { line -> CompilerMessage? in
+//            return CompilerMessage(message: line)
+//        })
+//
+//        return Array(filteredLines)
+        return from.compactMap { line -> CompilerMessage? in
             return CompilerMessage(message: line)
-        })
-
-        return Array(filteredLines)
+        }
     }
 
     func check(line: String, withRegex pattern: String) -> Bool {

--- a/Callisto/FastlaneParser.swift
+++ b/Callisto/FastlaneParser.swift
@@ -84,7 +84,7 @@ fileprivate extension FastlaneParser {
                 message.message.contains(warning) == false
             }
         })
-        return filtered
+        return filtered.uniqued()
     }
 
     func parseAnalyzerWarnings(_ lines: [String]) -> [CompilerMessage] {
@@ -102,7 +102,7 @@ fileprivate extension FastlaneParser {
                 message.message.contains(warning) == false
             }
         })
-        return filtered
+        return filtered.uniqued()
     }
 
     func parseUnitTestWarnings(_ lines: [String]) -> [UnitTestMessage] {
@@ -205,5 +205,4 @@ private extension String {
     func removeExtraSpaces() -> String {
         return self.replacingOccurrences(of: "[\\s\n]+", with: " ", options: .regularExpression, range: nil)
     }
-
 }

--- a/Callisto/FastlaneParser.swift
+++ b/Callisto/FastlaneParser.swift
@@ -55,7 +55,7 @@ fileprivate extension FastlaneParser {
 
     func parseSchemeFromFastlane(_ content: String) -> String? {
         guard let regex = try? NSRegularExpression(pattern: "\\| scheme[ ]*\\| [a-zA-Z ]*\\|\\n", options: .caseInsensitive) else {
-            print("Regular Expression Failed");
+            LogError("Regular Expression Failed");
             return nil
         }
 
@@ -117,7 +117,7 @@ fileprivate extension FastlaneParser {
 
     func parseExitStatusFromFastlane(_ content: String) -> Int {
         guard let regex = try? NSRegularExpression(pattern: "\\[[0-9]+:[0-9]+:[0-9]+]: Exit status: [0-9]+", options: .caseInsensitive) else {
-            print("Regular Expression Failed");
+            LogError("Regular Expression Failed");
             return 0
         }
 
@@ -169,17 +169,16 @@ private extension FastlaneParser {
         filteredString = filteredString.replacingOccurrences(of: "\r", with: "")
         filteredString = filteredString.replacingOccurrences(of: "\u{1b}", with: "")
 
-        guard let regex = try? NSRegularExpression(pattern: "\\[[0-9]+(m|;)[0-9]*(;)*[0-9]*m?", options: .caseInsensitive) else { print("Regular Expression Failed"); return "" }
+        guard let regex = try? NSRegularExpression(pattern: "\\[[0-9]+(m|;)[0-9]*(;)*[0-9]*m?", options: .caseInsensitive) else {
+            LogError("Regular Expression Failed");
+            return ""
+        }
+
         let range = NSMakeRange(0, filteredString.count)
         return regex.stringByReplacingMatches(in: filteredString, options: [], range: range, withTemplate: "")
     }
 
     func compilerMessages(from: [String]) -> [CompilerMessage] {
-//        let filteredLines = Set(from.compactMap { line -> CompilerMessage? in
-//            return CompilerMessage(message: line)
-//        })
-//
-//        return Array(filteredLines)
         return from.compactMap { line -> CompilerMessage? in
             return CompilerMessage(message: line)
         }
@@ -191,7 +190,7 @@ private extension FastlaneParser {
         do {
             try regex = NSRegularExpression(pattern: pattern, options: .caseInsensitive)
         } catch {
-            print("error: could not create Regex")
+            LogError("error: could not create Regex")
             return false
         }
 

--- a/Callisto/PodDependencyParser.swift
+++ b/Callisto/PodDependencyParser.swift
@@ -1,0 +1,39 @@
+//
+//  PodDependencyParser.swift
+//  ci-dependencies-check
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import Foundation
+
+
+class PodDependencyParser {
+
+    static func parse(content: String) -> [Dependency] {
+        let lines = content.split(separator: "\n")
+        let filteredLines = lines.filter { $0.starts(with: "-") }
+        var dependencies: [Dependency] = []
+        for line in filteredLines {
+            var components = line.components(separatedBy: " -> ")
+            let current = String(components[0].dropFirst(2)).split(separator: " ")
+            let name = String(current[0])
+            let currentVersionString = String(current[1])
+            components = components[1].components(separatedBy: " (")
+            let lockedVersionString = String(components[0])
+            let latestVersionString = String(components[1].dropLast().replacingOccurrences(of: "latest version ", with: ""))
+
+            let currentVersion = Version(string: currentVersionString)
+            let lockedVersion = Version(string: lockedVersionString)
+            let latestVersion = Version(string: latestVersionString)
+
+            dependencies.append(Dependency(name: name, currentVersion: currentVersion, lockedVersion: lockedVersion, upgradeableVersion: latestVersion))
+        }
+
+        return dependencies
+    }
+
+    static func filter(dependencies: [Dependency], with keywords: [String]) -> [Dependency] {
+        return Array(dependencies.drop { keywords.contains($0.name) })
+    }
+}

--- a/Callisto/PostGithubAction.swift
+++ b/Callisto/PostGithubAction.swift
@@ -61,6 +61,9 @@ final class GithubAction {
         let inputFiles = self.command.files
         guard inputFiles.hasElements else { quit(.invalidBuildInformationFile) }
 
+        LogMessage("Input Files: ")
+        _ = inputFiles.map { LogMessage($0.absoluteString) }
+
         let summaries = inputFiles.map { SummaryFile.read(url: $0) }.compactMap { result -> SummaryFile? in
             switch result {
             case .success(let info):
@@ -153,6 +156,9 @@ final class GithubAction {
         }
 
         let message = document.text()
+        LogMessage("Posting Comment on Github")
+        print(message)
+
         switch self.githubController.postComment(on: currentBranch, comment: Comment(body: message, id: nil)) {
         case .success:
             LogMessage("Successfully posted BuildReport to GitHub")
@@ -235,9 +241,9 @@ private extension GithubAction {
 
     func markdownText(from info: BuildInformation) -> String {
         var string = info.githubSummaryTitle
-        string += "\n\n"
 
         if info.errors.isEmpty && info.warnings.isEmpty && info.unitTests.isEmpty {
+            string += "\n\n"
             string += "Well done 👍"
             return string
         }

--- a/Callisto/PostGithubAction.swift
+++ b/Callisto/PostGithubAction.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ArgumentParser
+import MarkdownKit
 
 
 /// Responsible to read the build summaries and post them to github
@@ -60,7 +61,7 @@ final class GithubAction {
         let inputFiles = self.command.files
         guard inputFiles.hasElements else { quit(.invalidBuildInformationFile) }
 
-        let infos = self.filteredBuildInfos(inputFiles.map { BuildInformation.read(url: $0) }.compactMap { result -> BuildInformation? in
+        let summaries = inputFiles.map { SummaryFile.read(url: $0) }.compactMap { result -> SummaryFile? in
             switch result {
             case .success(let info):
                 return info
@@ -68,7 +69,25 @@ final class GithubAction {
                 LogError("\(error)")
                 return nil
             }
+        }
+
+        let infos = self.filteredBuildInfos(summaries.compactMap { file in
+            switch file {
+            case .build(let info):
+                return info
+            default:
+                return nil
+            }
         })
+
+        let dependencies = summaries.compactMap { file -> DependencyInformation? in
+            switch file {
+            case .dependencies(let info):
+                return info
+            default:
+                return nil
+            }
+        }
 
         guard infos.hasElements else { quit(.invalidBuildInformationFile) }
 
@@ -98,14 +117,47 @@ final class GithubAction {
             }
         }
 
+
+        var document = Document()
+
         if infos.hasElements {
-            let message = "# Build Summary\n\(infos.compactMap { self.markdownText(from: $0) }.joined(separator: "\n"))"
-            switch self.githubController.postComment(on: currentBranch, comment: Comment(body: message, id: nil)) {
-            case .success:
-                LogMessage("Successfully posted BuildReport to GitHub")
-            case .failure(let error):
-                LogError(error.localizedDescription)
+            document.addComponent(Title("Build Summary", header: .h1))
+            document.addComponent(EmptyLine())
+
+            for info in infos {
+                document.addComponent(Text(self.markdownText(from: info)))
             }
+        }
+
+        if dependencies.hasElements {
+            document.addComponent(Title("Dependencies", header: .h3))
+            document.addComponent(EmptyLine())
+
+
+            let outdated = dependencies.flatMap ({ $0.outdated })
+            if outdated.hasElements {
+                var table = Table(titles: Table.Row(columns: ["Name", "Current", "New"]))
+                for dependency in outdated {
+                    let row = Table.Row(columns: [
+                        dependency.name,
+                        dependency.currentVersion.description,
+                        dependency.upgradeableVersion.description
+                    ])
+
+                    table.addRow(row)
+                }
+                document.addComponent(table)
+            } else {
+                document.addComponent(Text("Everything Up-to-date 👍"))
+            }
+        }
+
+        let message = document.text()
+        switch self.githubController.postComment(on: currentBranch, comment: Comment(body: message, id: nil)) {
+        case .success:
+            LogMessage("Successfully posted BuildReport to GitHub")
+        case .failure(let error):
+            LogError(error.localizedDescription)
         }
 
         quit(.success)
@@ -181,7 +233,7 @@ private extension GithubAction {
         }
     }
 
-    func markdownText(from info: BuildInformation) -> String? {
+    func markdownText(from info: BuildInformation) -> String {
         var string = info.githubSummaryTitle
         string += "\n\n"
 
@@ -208,6 +260,25 @@ private extension GithubAction {
         string += "\n\n"
         return string
     }
+
+    /*
+    func markdownComponents(from info: BuildInformation) -> [MarkdownConformable] {
+        var components: [MarkdownConformable] = []
+        components.append(info.githubSummaryText)
+        components.append(EmptyLine())
+        components.append(EmptyLine())
+
+        if info.errors.isEmpty && info.warnings.isEmpty && info.unitTests.isEmpty {
+            components.append(Text("Well done 👍"))
+            return components
+        }
+
+        if info.errors.hasElements {
+            string += "\n\n"
+            string += info.errors.map { ":red_circle: **\($0.file):\($0.line)**\n\($0.message)" }.joined(separator: "\n\n")
+        }
+    }
+    */
 }
 
 private extension Comment {

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -63,6 +63,9 @@ final class PostSlackAction: NSObject {
         let inputFiles = self.command.files
         guard inputFiles.hasElements else { quit(.invalidBuildInformationFile) }
 
+        LogMessage("Input Files: ")
+        _ = inputFiles.map { LogMessage($0.absoluteString) }
+
         let summaries = inputFiles.map { SummaryFile.read(url: $0) }.compactMap { result -> SummaryFile? in
             switch result {
             case .success(let info):

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -63,12 +63,30 @@ final class PostSlackAction: NSObject {
         let inputFiles = self.command.files
         guard inputFiles.hasElements else { quit(.invalidBuildInformationFile) }
 
-        let infos = inputFiles.map { BuildInformation.read(url: $0) }.compactMap { result -> BuildInformation? in
+        let summaries = inputFiles.map { SummaryFile.read(url: $0) }.compactMap { result -> SummaryFile? in
             switch result {
             case .success(let info):
                 return info
             case .failure(let error):
                 LogError("\(error)")
+                return nil
+            }
+        }
+
+        let infos = summaries.compactMap { file -> BuildInformation? in
+            switch file {
+            case .build(let info):
+                return info
+            default:
+                return nil
+            }
+        }
+
+        let dependencies = summaries.compactMap { file -> DependencyInformation? in
+            switch file {
+            case .dependencies(let info):
+                return info
+            default:
                 return nil
             }
         }
@@ -79,7 +97,7 @@ final class PostSlackAction: NSObject {
         }
 
         let branch = self.currentBranch()
-        let slackMessage = self.makeSlackMessage(for: branch, infos: infos)
+        let slackMessage = self.makeSlackMessage(for: branch, infos: infos, dependencies: dependencies)
         guard let data = slackMessage.jsonDataRepresentation() else { quit(.jsonConversationFailed) }
 
         self.slackController.post(data: data)
@@ -101,7 +119,7 @@ private extension PostSlackAction {
         }
     }
 
-    func makeSlackMessage(for branch: Branch?, infos: [BuildInformation]) -> SlackMessage {
+    func makeSlackMessage(for branch: Branch?, infos: [BuildInformation], dependencies: [DependencyInformation]) -> SlackMessage {
         let ignoredKeywords = infos.flatMap {
             [
                 $0.config.ignore.values.compactMap { $0.warnings},
@@ -132,6 +150,11 @@ private extension PostSlackAction {
         unitTestAttachment.colorHex = "0077FF"
         message.add(attachment: unitTestAttachment)
 
+        // Dependencies
+        let outdated = dependencies.flatMap { $0.outdated }
+        let dependencyAttachment = self.makeSlackAttachment(outdated, type: .warning)
+        message.add(attachment: dependencyAttachment)
+
         return message
     }
 
@@ -148,6 +171,15 @@ private extension PostSlackAction {
         let attachment = SlackAttachment(type: type)
         for message in messages {
             attachment.addField(SlackField(message: message))
+        }
+        return attachment
+    }
+
+    func makeSlackAttachment(_ messages: [Dependency], type: SlackAttachmentType = .danger) -> SlackAttachment {
+        let attachment = SlackAttachment(type: type)
+        for message in messages {
+            attachment.addField(SlackField(title: "\(message.name) \(message.currentVersion.description)",
+                                           value: "New Version available: \(message.upgradeableVersion.description)"))
         }
         return attachment
     }

--- a/Callisto/SemanticVersion.swift
+++ b/Callisto/SemanticVersion.swift
@@ -1,0 +1,36 @@
+//
+//  SemanticVersion.swift
+//  Callisto
+//
+//  Created by Patrick Kladek on 23.11.21.
+//  Copyright © 2021 IdeasOnCanvas. All rights reserved.
+//
+
+import Foundation
+
+struct SemanticVersion {
+    let major: Int
+    let minor: Int
+    let bugfix: Int
+    let suffix: String?
+
+    init(major: Int, minor: Int, bugfix: Int, suffix: String? = nil) {
+        self.major = major
+        self.minor = minor
+        self.bugfix = bugfix
+        self.suffix = suffix
+    }
+}
+
+extension SemanticVersion: CustomStringConvertible {
+
+    var description: String {
+        return ["\(self.major)", "\(self.minor)", "\(self.bugfix)", self.suffix].compactMap { $0 }.joined(separator: ".")
+    }
+}
+
+extension SemanticVersion: Equatable { }
+
+extension SemanticVersion: Codable { }
+
+extension SemanticVersion: Hashable { }

--- a/Callisto/SlackCommunicationController.swift
+++ b/Callisto/SlackCommunicationController.swift
@@ -43,6 +43,6 @@ class SlackCommunicationController: NSObject {
 extension SlackCommunicationController: URLSessionDelegate {
 
     func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
-        print(error ?? "error")
+        LogError(error?.localizedDescription ?? "error")
     }
 }

--- a/Callisto/Sugar.swift
+++ b/Callisto/Sugar.swift
@@ -1,0 +1,15 @@
+//
+//  Sugar.swift
+//  ci-dependencies-check
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import Foundation
+
+extension Collection {
+
+    var hasElements: Bool {
+        return self.isEmpty == false
+    }
+}

--- a/Callisto/SummaryFile.swift
+++ b/Callisto/SummaryFile.swift
@@ -1,0 +1,33 @@
+//
+//  SummaryFile.swift
+//  Callisto
+//
+//  Created by Patrick Kladek on 23.11.21.
+//  Copyright © 2021 IdeasOnCanvas. All rights reserved.
+//
+
+import Foundation
+
+
+enum SummaryFile: Codable {
+    case dependencies(DependencyInformation)
+    case build(BuildInformation)
+}
+
+extension SummaryFile {
+
+    static func read(url: URL) -> Result<SummaryFile, Error> {
+        let data: Data
+        let decoder = JSONDecoder()
+        let info: SummaryFile
+
+        do {
+            data = try Data(contentsOf: url, options: .uncached)
+            info = try decoder.decode(SummaryFile.self, from: data)
+        } catch {
+            return .failure(error)
+        }
+
+        return .success(info)
+    }
+}

--- a/Callisto/Version.swift
+++ b/Callisto/Version.swift
@@ -1,0 +1,70 @@
+//
+//  Version.swift
+//  ci-dependencies-check
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import Foundation
+
+enum Version {
+    case semantic(SemanticVersion)
+    case other(String)
+
+    init(string: String) {
+        if let version = string.semanticVersion {
+            self = .semantic(version)
+        } else {
+            self = .other(string)
+        }
+    }
+}
+
+extension Version: CustomStringConvertible {
+
+    var description: String {
+        switch self {
+        case .semantic(let version):
+            return version.description
+        case .other(let string):
+            return string
+        }
+    }
+}
+
+extension Version: Equatable { }
+
+extension Version: Codable { }
+
+extension Version: Hashable { }
+
+extension String {
+
+    var isSemanticVersion: Bool {
+        let components = self.split { char in
+            return char == "." || char == "-"
+        }
+        return components.count >= 3 &&
+        components[0].allSatisfy { $0.isNumber } &&
+        components[1].allSatisfy { $0.isNumber } &&
+        components[2].first!.isNumber
+    }
+
+    var semanticVersion: SemanticVersion? {
+        guard self.isSemanticVersion else { return nil }
+
+        let components = self.split { char in
+            return char == "." || char == "-"
+        }
+
+        var suffix: String? = nil
+        if components.count > 3 {
+            suffix = components[3...(components.count-1)].map { String($0) }.joined(separator: ".")
+        }
+
+        return SemanticVersion(major: Int(components[0])!,
+                               minor: Int(components[1])!,
+                               bugfix: Int(components[2])!,
+                               suffix: suffix)
+    }
+}

--- a/Callisto/main.swift
+++ b/Callisto/main.swift
@@ -12,7 +12,7 @@ struct Callisto: ParsableCommand {
 
     static let configuration = CommandConfiguration(
         abstract: "A Swift command-line tool to parse fastlane build output",
-        subcommands: [Summarise.self, PostToGithub.self, PostToSlack.self])
+        subcommands: [Dependencies.self, Summarise.self, PostToGithub.self, PostToSlack.self])
 
     init() { }
 }

--- a/Dependencies/MarkdownKit/.gitignore
+++ b/Dependencies/MarkdownKit/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/Dependencies/MarkdownKit/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Dependencies/MarkdownKit/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Dependencies/MarkdownKit/Package.swift
+++ b/Dependencies/MarkdownKit/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MarkdownKit",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "MarkdownKit",
+            targets: ["MarkdownKit"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "MarkdownKit",
+            dependencies: []),
+        .testTarget(
+            name: "MarkdownKitTests",
+            dependencies: ["MarkdownKit"]),
+    ]
+)

--- a/Dependencies/MarkdownKit/README.md
+++ b/Dependencies/MarkdownKit/README.md
@@ -1,0 +1,3 @@
+# MarkdownKit
+
+A description of this package.

--- a/Dependencies/MarkdownKit/Sources/MarkdownKit/Document.swift
+++ b/Dependencies/MarkdownKit/Sources/MarkdownKit/Document.swift
@@ -1,0 +1,32 @@
+//
+//  Document.swift
+//  MarkdownKit
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import Foundation
+
+public struct Document {
+
+    private(set) var components: [MarkdownConformable] = []
+
+    public mutating func addComponent(_ component: MarkdownConformable) {
+        self.components.append(component)
+    }
+
+    public init() { }
+
+    public func text() -> String {
+        return self.lines.joined(separator: "\n")
+    }
+}
+
+// MARK: - MarkdownConformable
+
+extension Document: MarkdownConformable {
+
+    public var lines: [String] {
+        return self.components.flatMap { $0.lines }
+    }
+}

--- a/Dependencies/MarkdownKit/Sources/MarkdownKit/EmptyLine.swift
+++ b/Dependencies/MarkdownKit/Sources/MarkdownKit/EmptyLine.swift
@@ -1,0 +1,17 @@
+//
+//  EmptyLine.swift
+//  MarkdownKit
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import Foundation
+
+public struct EmptyLine: MarkdownConformable {
+
+    public var lines: [String] {
+        return [""]
+    }
+
+    public init() { }
+}

--- a/Dependencies/MarkdownKit/Sources/MarkdownKit/MarkdownConformable.swift
+++ b/Dependencies/MarkdownKit/Sources/MarkdownKit/MarkdownConformable.swift
@@ -1,0 +1,11 @@
+//
+//  MarkdownKit.swift
+//  MarkdownKit
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+public protocol MarkdownConformable {
+
+    var lines: [String] { get }
+}

--- a/Dependencies/MarkdownKit/Sources/MarkdownKit/MarkdownKit.swift
+++ b/Dependencies/MarkdownKit/Sources/MarkdownKit/MarkdownKit.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import Foundation

--- a/Dependencies/MarkdownKit/Sources/MarkdownKit/Table.swift
+++ b/Dependencies/MarkdownKit/Sources/MarkdownKit/Table.swift
@@ -1,0 +1,88 @@
+//
+//  Table.swift
+//  MarkdownKit
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import Foundation
+
+public struct Table {
+
+    public struct Row {
+        public typealias Column = String
+
+        public let columns: [Column]
+
+        public init(columns: [Column]) {
+            self.columns = columns
+        }
+
+        public var longestColumn: Int {
+            return self.columns.reduce(Int.min) { max($0, $1.count) }
+        }
+
+        public func line(equalWidth width: Int) -> String {
+            let elements = self.columns.map {
+                $0.padding(toLength: width, withPad: " ", startingAt: 0)
+            }
+            return "| " + elements.joined(separator: " | ") + " |"
+        }
+
+        public func separatorLine(width: Int) -> String {
+            let elements = repeatElement("".padding(toLength: width, withPad: "-", startingAt: 0), count: self.columns.count)
+            return "| " + elements.joined(separator: " | ") + " |"
+        }
+    }
+
+    private let titleRow: Row
+    private var rows: [Row] = []
+
+    // MARK: - Lifecycle
+
+    public
+    init(titles: Row) {
+        self.titleRow = titles
+    }
+
+    public
+    mutating func addRow(_ row: Row) {
+        self.rows.append(row)
+    }
+
+    public
+    mutating func addRows(_ rows: [Row]) {
+        self.rows.append(contentsOf: rows)
+    }
+}
+
+// MARK: - MarkdownConformable
+
+extension Table: MarkdownConformable {
+
+    public var lines: [String] {
+        let width = self.longestColumn
+        var lines: [String] = []
+        lines.append(self.titleRow.line(equalWidth: width))
+        lines.append(self.titleRow.separatorLine(width: width))
+
+        for row in self.rows {
+            lines.append(row.line(equalWidth: width))
+        }
+
+        return lines
+    }
+}
+
+// MARK: - Private
+
+private extension Table {
+
+    var longestColumn: Int {
+        var width = self.titleRow.longestColumn
+        for row in self.rows {
+            width = max(row.longestColumn, width)
+        }
+        return width
+    }
+}

--- a/Dependencies/MarkdownKit/Sources/MarkdownKit/Text.swift
+++ b/Dependencies/MarkdownKit/Sources/MarkdownKit/Text.swift
@@ -1,0 +1,21 @@
+//
+//  Text.swift
+//  MarkdownKit
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import Foundation
+
+public struct Text: MarkdownConformable {
+
+    let text: String
+
+    public init(_ text: String) {
+        self.text = text
+    }
+
+    public var lines: [String] {
+        return [self.text]
+    }
+}

--- a/Dependencies/MarkdownKit/Sources/MarkdownKit/Title.swift
+++ b/Dependencies/MarkdownKit/Sources/MarkdownKit/Title.swift
@@ -1,0 +1,35 @@
+//
+//  Title.swift
+//  MarkdownKit
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import Foundation
+
+public struct Title: MarkdownConformable {
+
+    public enum Header: Int {
+        case h1 = 1
+        case h2
+        case h3
+        case h4
+        case h5
+        case h6
+    }
+
+    let title: String
+    let header: Header
+
+    public init(_ title: String, header: Header = .h1) {
+        self.title = title
+        self.header = header
+    }
+
+    public var lines: [String] {
+        let line = (1...self.header.rawValue).reduce("") { partialResult, _ in
+            return partialResult + "#"
+        } + " \(self.title)"
+        return [line]
+    }
+}

--- a/Dependencies/MarkdownKit/Tests/MarkdownKitTests/MarkdownKitTests.swift
+++ b/Dependencies/MarkdownKit/Tests/MarkdownKitTests/MarkdownKitTests.swift
@@ -1,0 +1,66 @@
+//
+//  MarkdownKitTests.swift
+//  MarkdownKit
+//
+//  Created by Patrick Kladek on 16.11.21.
+//
+
+import XCTest
+@testable import MarkdownKit
+
+
+final class MarkdownKitTests: XCTestCase {
+
+    func testTitle() throws {
+        let title = Title("Hello World", header: .h4)
+        let lines = title.lines
+        XCTAssertEqual(lines.count, 1)
+        XCTAssertEqual(lines[0], "#### Hello World")
+    }
+
+    func testText() throws {
+        let text = Text("Hello World")
+        let lines = text.lines
+        XCTAssertEqual(lines.count, 1)
+        XCTAssertEqual(lines[0], "Hello World")
+    }
+
+    func testTable() throws {
+        var table = Table(titles: Table.Row(columns: ["Library", "Current", "New"]))
+        table.addRow(Table.Row(columns: ["Alamofire", "2.1.0", "3.0.0"]))
+
+        let text = table.lines.joined(separator: "\n")
+        let expected =
+        """
+        | Library   | Current   | New       |
+        | --------- | --------- | --------- |
+        | Alamofire | 2.1.0     | 3.0.0     |
+        """
+
+        XCTAssertEqual(text, expected)
+    }
+
+    func testDocument() throws {
+        var doc = Document()
+        doc.addComponent(Title("New Version Available", header: .h3))
+        doc.addComponent(EmptyLine())
+
+        var table = Table(titles: Table.Row(columns: ["Library", "Current", "New"]))
+        table.addRow(Table.Row(columns: ["Alamofire", "2.1.0", "3.0.0"]))
+        doc.addComponent(table)
+
+        let lines = doc.lines
+        let text = doc.text()
+        let expected =
+        """
+        ### New Version Available
+
+        | Library   | Current   | New       |
+        | --------- | --------- | --------- |
+        | Alamofire | 2.1.0     | 3.0.0     |
+        """
+
+        XCTAssertEqual(lines.count, 5)
+        XCTAssertEqual(text, expected)
+    }
+}


### PR DESCRIPTION
### Description

Run `pod outdated` as part of CI and parse its results. 
Allow to ignore some Dependencies as updating may not be possible right now.
Example output:

```
% pod outdated 
Updating spec repo `trunk`
Analyzing dependencies
The following pod updates are available:
- Alamofire 4.9.1 -> 4.9.1 (latest version 5.4.4)
- AlamofireImage 3.6.0 -> 3.6.0 (latest version 4.2.0)
- PromiseKit 6.5.0 -> 6.5.0 (latest version 6.15.3)
- Turf 1.2.0 -> 1.2.0 (latest version 2.1.0)
```

### Tasks

- [x] Extend Callisto to run `pod outdated`
- [x] Parse results so we know about current, locked and upgradeable Version
- [x] Save parsed results to disk
- [x] Extend GitHub & Slack Action for new input file

### Infos For Reviewer

