### PR TITLE
Use system PATH variable for internal subtask

### DIFF
--- a/Callisto.xcodeproj/xcshareddata/xcschemes/Callisto.xcscheme
+++ b/Callisto.xcodeproj/xcshareddata/xcschemes/Callisto.xcscheme
@@ -56,6 +56,18 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "PATH"
+            value = "/usl/local/bin:$PATH"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "LANG"
+            value = "en_US.UTF-8"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Callisto/Common.swift
+++ b/Callisto/Common.swift
@@ -75,10 +75,6 @@ extension ExitCodes: CustomStringConvertible {
     }
 }
 
-struct AppInfo {
-    static let version = "2.0"
-}
-
 func time() -> String {
     return DateFormatter.localizedString(from: Date(), dateStyle: .none, timeStyle: .medium)
 }

--- a/Callisto/DependenciesAction.swift
+++ b/Callisto/DependenciesAction.swift
@@ -68,22 +68,12 @@ private extension Dependencies {
         let task = Process()
         let outputPipe = Pipe()
         let errorPipe = Pipe()
-        let environment = [
-            "LANG": "en_US.UTF-8",
-            "PATH": [
-                "/usr/local/bin",
-                "/usr/bin",
-                "/bin",
-                "/usr/sbin",
-                "/sbin",
-            ].joined(separator: ":")
-        ]
 
         task.standardOutput = outputPipe
         task.standardError = errorPipe
         task.arguments = ["-c", command]
         task.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        task.environment = environment
+        task.environment = ProcessInfo.processInfo.environment
         task.currentDirectoryURL = currentDirectoryURL
 
         LogMessage("$ \(command)")

--- a/Callisto/main.swift
+++ b/Callisto/main.swift
@@ -12,6 +12,7 @@ struct Callisto: ParsableCommand {
 
     static let configuration = CommandConfiguration(
         abstract: "A Swift command-line tool to parse fastlane build output",
+        version: "2.1",
         subcommands: [Dependencies.self, Summarise.self, PostToGithub.self, PostToSlack.self, FailBuildAction.self])
 
     init() { }


### PR DESCRIPTION
### Description

macOS 13 removed `/usr/local/bin` folder. Callisto used this and others hardcoded as $PATH variable for its subtasks, which then failed. Use the parent Process $PATH variable to be future proof.

### Tasks

- [x] Use system PATH variable for internal subtask

### Infos for Reviewer

Not all environment variables are set when launched from Xcode. To be as close to Terminal we have to set some Variables ourselves:

![Bildschirmfoto 2022-06-20 um 16 46 40](https://user-images.githubusercontent.com/18739004/174627636-a859b6b1-746b-4c70-8cbc-17f40fa6e82a.png)