### PR TITLE
Log warnings on fail build

### DIFF
--- a/Callisto/Common.swift
+++ b/Callisto/Common.swift
@@ -70,7 +70,7 @@ extension ExitCodes: CustomStringConvertible {
         case .invalidOutputFile:
             return "invalid output file. Usage -output \"/path/to/file\""
         case .containsWarnings:
-            return "The commits contains warnings. Please resovle all warnings."
+            return "This build contains warnings. Please resovle them."
         }
     }
 }

--- a/Callisto/FailBuildAction.swift
+++ b/Callisto/FailBuildAction.swift
@@ -25,8 +25,7 @@ final class FailBuildAction: ParsableCommand {
         let inputFiles = self.files
         guard inputFiles.hasElements else { quit(.invalidBuildInformationFile) }
 
-        LogMessage("Input Files: ")
-        _ = inputFiles.map { LogMessage($0.absoluteString) }
+        _ = inputFiles.map { LogMessage("Processing \($0.absoluteString)") }
 
         let summaries = inputFiles.map { SummaryFile.read(url: $0) }.compactMap { result -> SummaryFile? in
             switch result {
@@ -47,8 +46,11 @@ final class FailBuildAction: ParsableCommand {
             }
         }
 
-        let warnings = infos.flatMap { $0.warnings }
-        guard warnings.isEmpty else { quit(.containsWarnings) }
+        let warnings = infos.flatMap { $0.warnings }.uniqued()
+        guard warnings.isEmpty else {
+            warnings.forEach { LogWarning($0.description) }
+            quit(.containsWarnings)
+        }
 
         quit(.success)
     }


### PR DESCRIPTION
### Description

Log all warnings before exit in FailBuildAction.

### Tasks

- [x] Log Warnings for FailBuildAction
- [x] Improve Exit Message

### Infos for Reviewer

```
13:39:22 [MESSAGE] Processing file:///Users/patrick/Desktop/File.json
13:39:22 [WARNING] CheckboxToggleStyle.swift [Line: 18] Multiple Closures with Trailing Closure Violation: Trailing closure syntax should not be used when passing more than one closure argument. (multiple_closures_with_trailing_closure)
13:39:22 [ ERROR ] This build contains warnings. Please resovle them.
```