### PR TITLE
Fix wrongly not silenced messages

### DIFF
--- a/Callisto.xcodeproj/project.pbxproj
+++ b/Callisto.xcodeproj/project.pbxproj
@@ -13,6 +13,26 @@
 		CD0E20D923040AFE001D9159 /* Result+Sugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0E20D823040AFE001D9159 /* Result+Sugar.swift */; };
 		CD0E20DB230447E8001D9159 /* Collection+Sugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0E20DA230447E8001D9159 /* Collection+Sugar.swift */; };
 		CD512D8E2008C1F9002EB718 /* ios_build_4822.log in Resources */ = {isa = PBXBuildFile; fileRef = CD512D8D2008C1F9002EB718 /* ios_build_4822.log */; };
+		CD56C6D228CA575A005B81F3 /* ios_build_2074.log in Resources */ = {isa = PBXBuildFile; fileRef = CD56C6D128CA575A005B81F3 /* ios_build_2074.log */; };
+		CD56C6EA28CA5F56005B81F3 /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = CD56C6E928CA5F56005B81F3 /* Yams */; };
+		CD56C6EB28CA5F60005B81F3 /* SummaryFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA23B274CE06A007606C4 /* SummaryFile.swift */; };
+		CD56C6EC28CA5F71005B81F3 /* DependenciesAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA206274CD877007606C4 /* DependenciesAction.swift */; };
+		CD56C6ED28CA5F71005B81F3 /* PostSlackAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB5A97B251A722D00CC486F /* PostSlackAction.swift */; };
+		CD56C6EE28CA5F71005B81F3 /* FailBuildAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81E3743727ABFE3B00EB10EA /* FailBuildAction.swift */; };
+		CD56C6EF28CA5F74005B81F3 /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA231274CD9D1007606C4 /* Version.swift */; };
+		CD56C6F028CA5F74005B81F3 /* Dependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA230274CD9D1007606C4 /* Dependency.swift */; };
+		CD56C6F128CA5F74005B81F3 /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA237274CDA0E007606C4 /* SemanticVersion.swift */; };
+		CD56C6F228CA5F74005B81F3 /* DependencyInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA239274CDB4D007606C4 /* DependencyInformation.swift */; };
+		CD56C6F328CA5F77005B81F3 /* PackageManagerDependencyParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA94E94283CBB2A001E4521 /* PackageManagerDependencyParser.swift */; };
+		CD56C6F428CA5F77005B81F3 /* PodDependencyParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8CA22F274CD9D1007606C4 /* PodDependencyParser.swift */; };
+		CD56C6F528CA5F80005B81F3 /* Collection+Sugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0E20DA230447E8001D9159 /* Collection+Sugar.swift */; };
+		CD56C6F628CA5F8B005B81F3 /* String+Sugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB22D302303F985002A1EF3 /* String+Sugar.swift */; };
+		CD56C6F728CA5F92005B81F3 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9DF3AA22FC4AEF00779F6F /* Comment.swift */; };
+		CD56C6F828CA5F96005B81F3 /* Output.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9DF3A622FC294E00779F6F /* Output.swift */; };
+		CD56C6F928CA5F96005B81F3 /* Check.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9DF3A822FC2A1A00779F6F /* Check.swift */; };
+		CD56C6FA28CA609D005B81F3 /* Result+Sugar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0E20D823040AFE001D9159 /* Result+Sugar.swift */; };
+		CD56C6FC28CA60B3005B81F3 /* MarkdownKit in Frameworks */ = {isa = PBXBuildFile; productRef = CD56C6FB28CA60B3005B81F3 /* MarkdownKit */; };
+		CD56C70028CA60C3005B81F3 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = CD56C6FF28CA60C3005B81F3 /* ArgumentParser */; };
 		CD8BBDEE1EE009C600E8EE2E /* SlackAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDDE1EE009C600E8EE2E /* SlackAction.swift */; };
 		CD8BBDEF1EE009C600E8EE2E /* SlackAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDDF1EE009C600E8EE2E /* SlackAttachment.swift */; };
 		CD8BBDF01EE009C600E8EE2E /* SlackCommunicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8BBDE01EE009C600E8EE2E /* SlackCommunicationController.swift */; };
@@ -117,6 +137,7 @@
 		CD4E0F6D22F4475A00C31E08 /* PostGithubAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostGithubAction.swift; sourceTree = "<group>"; };
 		CD512D8D2008C1F9002EB718 /* ios_build_4822.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ios_build_4822.log; sourceTree = "<group>"; };
 		CD512D8F2008C257002EB718 /* GithubCommunicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubCommunicationTests.swift; sourceTree = "<group>"; };
+		CD56C6D128CA575A005B81F3 /* ios_build_2074.log */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ios_build_2074.log; sourceTree = "<group>"; };
 		CD8320FE1EE7DF640029DBE0 /* CallistoTest.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CallistoTest.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD8321001EE7DF640029DBE0 /* ParserTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserTest.swift; sourceTree = "<group>"; };
 		CD8321021EE7DF640029DBE0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -163,6 +184,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD56C70028CA60C3005B81F3 /* ArgumentParser in Frameworks */,
+				CD56C6FC28CA60B3005B81F3 /* MarkdownKit in Frameworks */,
+				CD56C6EA28CA5F56005B81F3 /* Yams in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -205,6 +229,7 @@
 			children = (
 				CD33AF6D22F073D1002EC27C /* ios_output_failing.txt */,
 				CDF0070C20760B1900257FCC /* ios_build_8745.log */,
+				CD56C6D128CA575A005B81F3 /* ios_build_2074.log */,
 				CDF0070D20760B1900257FCC /* mac_build_8745.log */,
 				CDF007072074FAC200257FCC /* ios_build_8731.log */,
 				CDF007062074FAC200257FCC /* mac_build_8731.log */,
@@ -385,6 +410,11 @@
 			dependencies = (
 			);
 			name = CallistoTest;
+			packageProductDependencies = (
+				CD56C6E928CA5F56005B81F3 /* Yams */,
+				CD56C6FB28CA60B3005B81F3 /* MarkdownKit */,
+				CD56C6FF28CA60C3005B81F3 /* ArgumentParser */,
+			);
 			productName = CallistoTest;
 			productReference = CD8320FE1EE7DF640029DBE0 /* CallistoTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -468,6 +498,7 @@
 				CDF0070F20760B1900257FCC /* mac_build_8745.log in Resources */,
 				CDF0070E20760B1900257FCC /* ios_build_8745.log in Resources */,
 				CD081CBE1EE7F1D700F537B3 /* mac_build_4454.log in Resources */,
+				CD56C6D228CA575A005B81F3 /* ios_build_2074.log in Resources */,
 				CD081CBC1EE7F19100F537B3 /* ios_build_4454.log in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -485,27 +516,43 @@
 				CD9DF13822FC1C6F00779F6F /* URLSession+synchronousTask.swift in Sources */,
 				CD9DF13622FC1C6F00779F6F /* Branch.swift in Sources */,
 				CD9DF13B22FC1C6F00779F6F /* Dictionary+Optional.swift in Sources */,
+				CD56C6F928CA5F96005B81F3 /* Check.swift in Sources */,
 				CD9DF12722FC16EF00779F6F /* GithubCommunicationTests.swift in Sources */,
 				CD9DF12822FC16EF00779F6F /* SlackCommunicationTests.swift in Sources */,
+				CD56C6F728CA5F92005B81F3 /* Comment.swift in Sources */,
+				CD56C6F528CA5F80005B81F3 /* Collection+Sugar.swift in Sources */,
+				CD56C6F828CA5F96005B81F3 /* Output.swift in Sources */,
+				CD56C6EB28CA5F60005B81F3 /* SummaryFile.swift in Sources */,
 				CD9DF14222FC1C9100779F6F /* SlackField.swift in Sources */,
+				CD56C6EF28CA5F74005B81F3 /* Version.swift in Sources */,
+				CD56C6F128CA5F74005B81F3 /* SemanticVersion.swift in Sources */,
 				CD9DF13A22FC1C6F00779F6F /* DictionaryConvertable.swift in Sources */,
 				CD9DF13522FC1C6F00779F6F /* GithubRepository.swift in Sources */,
 				CD9DF13022FC1C6F00779F6F /* CompilerMessage.swift in Sources */,
+				CD56C6F228CA5F74005B81F3 /* DependencyInformation.swift in Sources */,
 				CD9DF13322FC1C6F00779F6F /* GitHubCommunicationController.swift in Sources */,
 				CD9DF13E22FC1C6F00779F6F /* Common.swift in Sources */,
 				CD9DF13D22FC1C6F00779F6F /* URL+Temp.swift in Sources */,
 				CD9DF13122FC1C6F00779F6F /* UnitTestMessage.swift in Sources */,
 				CD9DF14322FC1C9100779F6F /* SlackAction.swift in Sources */,
+				CD56C6FA28CA609D005B81F3 /* Result+Sugar.swift in Sources */,
 				CD9DF13F22FC1C9100779F6F /* SlackCommunicationController.swift in Sources */,
 				CD9DF12B22FC1C6F00779F6F /* SummariseAction.swift in Sources */,
 				CD9DF13222FC1C6F00779F6F /* BuildInformation.swift in Sources */,
+				CD56C6F628CA5F8B005B81F3 /* String+Sugar.swift in Sources */,
+				CD56C6F328CA5F77005B81F3 /* PackageManagerDependencyParser.swift in Sources */,
 				CD9DF12922FC16EF00779F6F /* GithubModelTests.swift in Sources */,
 				CD9DF12F22FC1C6F00779F6F /* FastlaneParser.swift in Sources */,
 				CD9DF12D22FC1C6F00779F6F /* ExtractBuildInformationController.swift in Sources */,
+				CD56C6ED28CA5F71005B81F3 /* PostSlackAction.swift in Sources */,
+				CD56C6F428CA5F77005B81F3 /* PodDependencyParser.swift in Sources */,
 				CD9DF13722FC1C6F00779F6F /* Annotation.swift in Sources */,
+				CD56C6EE28CA5F71005B81F3 /* FailBuildAction.swift in Sources */,
 				CDAE77842705B68600651B95 /* PostGithubAction.swift in Sources */,
 				CD9DF14022FC1C9100779F6F /* SlackMessage.swift in Sources */,
 				CD9DF13422FC1C6F00779F6F /* GithubAccess.swift in Sources */,
+				CD56C6EC28CA5F71005B81F3 /* DependenciesAction.swift in Sources */,
+				CD56C6F028CA5F74005B81F3 /* Dependency.swift in Sources */,
 				CD9DF14122FC1C9100779F6F /* SlackAttachment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -796,6 +843,20 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		CD56C6E928CA5F56005B81F3 /* Yams */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CDF2AD752706D03B00DED1A1 /* XCRemoteSwiftPackageReference "Yams" */;
+			productName = Yams;
+		};
+		CD56C6FB28CA60B3005B81F3 /* MarkdownKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MarkdownKit;
+		};
+		CD56C6FF28CA60C3005B81F3 /* ArgumentParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CDAE777F2705865A00651B95 /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
+			productName = ArgumentParser;
+		};
 		CD8CA22C274CD9A4007606C4 /* MarkdownKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MarkdownKit;

--- a/Callisto/FastlaneParser.swift
+++ b/Callisto/FastlaneParser.swift
@@ -99,9 +99,9 @@ fileprivate extension FastlaneParser {
 
             for rule in self.config.ignore {
                 let file = rule.key
-                if message.url.absoluteString.contains(file) || file == "*" {
+                if message.url.absoluteString.contains(file) || file.last == "*" {
                     for warning in (rule.value.warnings ?? []) {
-                        if message.message.lowercased().contains(warning.lowercased()) {
+                        if message.message.lowercased().contains(warning.lowercased()) || warning == "*" {
                             match = false
                         }
                     }

--- a/Callisto/FastlaneParser.swift
+++ b/Callisto/FastlaneParser.swift
@@ -95,19 +95,17 @@ fileprivate extension FastlaneParser {
         let warnings = self.compilerMessages(from: warningLines)
 
         let filtered = warnings.filter { message in
-            var match: Bool = true
-
             for rule in self.config.ignore {
                 let file = rule.key
                 if message.url.absoluteString.contains(file) || file.last == "*" {
                     for warning in (rule.value.warnings ?? []) {
                         if message.message.lowercased().contains(warning.lowercased()) || warning == "*" {
-                            match = false
+                            return false
                         }
                     }
                 }
             }
-            return match
+            return true
         }
         return filtered.uniqued()
     }
@@ -153,6 +151,8 @@ fileprivate extension FastlaneParser {
         return .success(-1)
     }
 }
+
+// MARK: - Private
 
 private extension FastlaneParser {
 

--- a/Callisto/FastlaneParser.swift
+++ b/Callisto/FastlaneParser.swift
@@ -97,7 +97,7 @@ fileprivate extension FastlaneParser {
         let filtered = warnings.filter { message in
             for rule in self.config.ignore {
                 let file = rule.key
-                if message.url.absoluteString.contains(file) || file.last == "*" {
+                if message.url.absoluteString.contains(file) {
                     for warning in (rule.value.warnings ?? []) {
                         if message.message.lowercased().contains(warning.lowercased()) || warning == "*" {
                             return false

--- a/Callisto/FastlaneParser.swift
+++ b/Callisto/FastlaneParser.swift
@@ -47,6 +47,9 @@ class FastlaneParser {
                                              unitTests: self.parseUnitTestWarnings(lines),
                                              config: self.config)
 
+        self.buildSummary.errors.forEach { LogError($0.description) }
+        self.buildSummary.warnings.forEach { LogWarning($0.description) }
+        self.buildSummary.unitTests.forEach { LogWarning($0.description) }
         return self.parseExitStatusFromFastlane(trimmedContent)
     }
 }
@@ -96,7 +99,7 @@ fileprivate extension FastlaneParser {
 
             for rule in self.config.ignore {
                 let file = rule.key
-                if message.file.contains(file) || file == "*" {
+                if message.url.absoluteString.contains(file) || file == "*" {
                     for warning in (rule.value.warnings ?? []) {
                         if message.message.lowercased().contains(warning.lowercased()) {
                             match = false

--- a/Callisto/PackageManagerDependencyParser.swift
+++ b/Callisto/PackageManagerDependencyParser.swift
@@ -19,9 +19,9 @@ class PackageManagerDependencyParser {
         for line in filteredLines {
             var components = line.components(separatedBy: .whitespaces)
             components.removeAll(where: { $0.count == 0 })
-            let name = String(components[0])
-            let currentVersionString = String(components[1])
-            let latestVersionString = String(components[2])
+            let name = String(components[1])
+            let currentVersionString = String(components[3])
+            let latestVersionString = String(components[5])
 
             let currentVersion = Version(string: currentVersionString)
             let latestVersion = Version(string: latestVersionString)

--- a/CallistoTest/GithubCommunicationTests.swift
+++ b/CallistoTest/GithubCommunicationTests.swift
@@ -44,7 +44,7 @@ private extension GithubCommunicationTests {
         let repository = settings["repository"]!
 
 
-        let account = GithubAccount(username: username, token: token)
-        return GitHubCommunicationController(account: account, repository: GithubRepository(organisation: organisation, repository: repository))
+        let account = GithubAccess(token: token)
+        return GitHubCommunicationController(access: account, repository: GithubRepository(organisation: organisation, repository: repository))
     }
 }

--- a/CallistoTest/ParserTest.swift
+++ b/CallistoTest/ParserTest.swift
@@ -15,7 +15,8 @@ class CallistoTest: XCTestCase {
         guard let fastlaneOutputURL = Bundle.init(for: type(of: self)).url(forResource: "ios_build_4454", withExtension: "log") else { XCTFail(); return; }
         guard let fastlaneContent = try? String.init(contentsOf: fastlaneOutputURL, encoding: .utf8) else { XCTFail(); return; }
 
-        let parser = FastlaneParser(content: fastlaneContent, ignoredKeywords: ["todo"])
+        let config = Config(ignore: ["*": Config.Details(warnings: ["todo"], errors: nil, tests: nil)])
+        let parser = FastlaneParser(content: fastlaneContent, config: config)
         XCTAssertEqual(65, parser.parse())
 
         XCTAssertEqual(parser.buildSummary.errors.count, 0)
@@ -27,7 +28,8 @@ class CallistoTest: XCTestCase {
         guard let fastlaneOutputURL = Bundle.init(for: type(of: self)).url(forResource: "mac_build_4454", withExtension: "log") else { XCTFail(); return; }
         guard let fastlaneContent = try? String.init(contentsOf: fastlaneOutputURL, encoding: .utf8) else { XCTFail(); return; }
 
-        let parser = FastlaneParser(content: fastlaneContent, ignoredKeywords: ["todo"])
+        let config = Config(ignore: ["*": Config.Details(warnings: ["todo"], errors: nil, tests: nil)])
+        let parser = FastlaneParser(content: fastlaneContent, config: config)
         XCTAssertEqual(65, parser.parse())
 
         XCTAssertEqual(parser.buildSummary.errors.count, 2)
@@ -39,8 +41,9 @@ class CallistoTest: XCTestCase {
         guard let fastlaneOutputURL = Bundle.init(for: type(of: self)).url(forResource: "ios_build_4822", withExtension: "log") else { XCTFail(); return; }
         guard let fastlaneContent = try? String.init(contentsOf: fastlaneOutputURL, encoding: .utf8) else { XCTFail(); return; }
 
-        let parser = FastlaneParser(content: fastlaneContent, ignoredKeywords: ["BITCrashManager", "todo"])
-        XCTAssertEqual(-1, parser.parse())
+        let config = Config(ignore: ["*": Config.Details(warnings: ["BITCrashManager", "todo"], errors: nil, tests: nil)])
+        let parser = FastlaneParser(content: fastlaneContent, config: config)
+        XCTAssertEqual(0, parser.parse())
 
         print(parser.buildSummary.errors.count)
         print(parser.buildSummary.warnings.count)
@@ -51,7 +54,8 @@ class CallistoTest: XCTestCase {
         guard let fastlaneOutputURL = Bundle.init(for: type(of: self)).url(forResource: "ios_build_8745", withExtension: "log") else { XCTFail(); return; }
         guard let fastlaneContent = try? String.init(contentsOf: fastlaneOutputURL, encoding: .utf8) else { XCTFail(); return; }
 
-        let parser = FastlaneParser(content: fastlaneContent, ignoredKeywords: ["todo"])
+        let config = Config(ignore: ["*": Config.Details(warnings: ["todo"], errors: nil, tests: nil)])
+        let parser = FastlaneParser(content: fastlaneContent, config: config)
         XCTAssertEqual(65, parser.parse())
 
         XCTAssertEqual(parser.buildSummary.errors.count, 0)
@@ -63,7 +67,8 @@ class CallistoTest: XCTestCase {
         guard let fastlaneOutputURL = Bundle.init(for: type(of: self)).url(forResource: "mac_build_8745", withExtension: "log") else { XCTFail(); return; }
         guard let fastlaneContent = try? String.init(contentsOf: fastlaneOutputURL, encoding: .utf8) else { XCTFail(); return; }
 
-        let parser = FastlaneParser(content: fastlaneContent, ignoredKeywords: ["todo"])
+        let config = Config(ignore: ["*": Config.Details(warnings: ["todo"], errors: nil, tests: nil)])
+        let parser = FastlaneParser(content: fastlaneContent, config: config)
         XCTAssertEqual(65, parser.parse())
 
         XCTAssertEqual(parser.buildSummary.errors.count, 0)

--- a/CallistoTest/ios_build_2074.log
+++ b/CallistoTest/ios_build_2074.log
@@ -1,0 +1,4784 @@
+Push event to branch feature/IOS-4984-route-planner-alignment
+Connecting to https://api.github.com using 5e83c4c3-cb12-47a0-bbf4-7d2cdee3766b
+Obtained Jenkinsfile from 06fad65c560c12ace9690f524b4cf6da528819d8
+[Pipeline] Start of Pipeline
+[Pipeline] node
+Running on Bikemap Office iMac in /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment
+[Pipeline] {
+[Pipeline] stage
+[Pipeline] { (Declarative: Checkout SCM)
+[Pipeline] checkout
+The recommended git tool is: git
+using credential 7ee70145-4367-467a-a948-8518248d6123
+Cloning the remote Git repository
+Cloning repository git@github.com:bikemap/bikemap-x-ios.git
+ > git init /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment # timeout=10
+Fetching upstream changes from git@github.com:bikemap/bikemap-x-ios.git
+ > git --version # timeout=10
+ > git --version # 'git version 2.37.0 (Apple Git-136)'
+using GIT_SSH to set credentials 
+ > git fetch --tags --force --progress -- git@github.com:bikemap/bikemap-x-ios.git +refs/heads/*:refs/remotes/origin/* # timeout=30
+Avoid second fetch
+Checking out Revision 06fad65c560c12ace9690f524b4cf6da528819d8 (feature/IOS-4984-route-planner-alignment)
+ > git config remote.origin.url git@github.com:bikemap/bikemap-x-ios.git # timeout=10
+ > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
+ > git config core.sparsecheckout # timeout=10
+ > git checkout -f 06fad65c560c12ace9690f524b4cf6da528819d8 # timeout=30
+Commit message: "IOS-4984 Hide bike computer and tab bar in route planner mode"
+First time build. Skipping changelog.
+ > git --version # timeout=10
+ > git --version # 'git version 2.37.0 (Apple Git-136)'
+[Pipeline] }
+[Pipeline] // stage
+[Pipeline] withEnv
+[Pipeline] {
+[Pipeline] stage
+[Pipeline] { (Dependencies)
+[Pipeline] sh
++ pod update
+Update all pods
+Updating local specs repositories
+Analyzing dependencies
+Pre-downloading: `AwaitKit` from `https://github.com/yannickl/AwaitKit.git`
+Pre-downloading: `ImageViewer` from `https://github.com/Krisiacik/ImageViewer.git`
+Pre-downloading: `Polyline` from `https://github.com/raphaelmor/Polyline.git`
+Pre-downloading: `RangeSeekSlider` from `https://github.com/WorldDownTown/RangeSeekSlider.git`
+Pre-downloading: `maplibre-pod` from `https://github.com/bikemap/maplibre-pod.git`, tag `0.3.0`
+Downloading dependencies
+Installing Alamofire (4.9.1)
+Installing AlamofireImage (3.6.0)
+Installing AwaitKit (5.2.0)
+Installing BartyCrouch (4.8.0)
+Installing FastEasyMapping (1.2.2)
+Installing Firebase (9.5.0)
+Installing FirebaseABTesting (9.5.0)
+Installing FirebaseAnalytics (9.5.0)
+Installing FirebaseCore (9.5.0)
+Installing FirebaseCoreDiagnostics (9.5.0)
+Installing FirebaseCoreInternal (9.5.0)
+Installing FirebaseCrashlytics (9.5.0)
+Installing FirebaseDynamicLinks (9.5.0)
+Installing FirebaseInAppMessaging (9.5.0-beta)
+Installing FirebaseInstallations (9.5.0)
+Installing FirebaseMessaging (9.5.0)
+Installing FirebaseRemoteConfig (9.5.0)
+Installing GEOSwift (9.0.0)
+Installing GoogleAppMeasurement (9.5.0)
+Installing GoogleDataTransport (9.2.0)
+Installing GoogleUtilities (7.7.0)
+Installing ImageViewer (6.0.0)
+Installing LicensePlist (3.22.5)
+Installing MapboxCommon (9.2.0)
+Installing MapboxCoreNavigation (1.4.0)
+Installing MapboxDirections (1.2.0)
+Installing MapboxNavigation (1.4.0)
+Installing MapboxNavigationNative (32.0.0)
+Installing MapboxSpeech (1.0.0)
+Installing Polyline (5.0.3)
+Installing PromiseKit (6.5.0)
+Installing PromisesObjC (2.1.1)
+Installing PryntTrimmerView (4.0.2)
+Installing RangeSeekSlider (1.8.0)
+Installing Solar (2.1.0)
+Installing SwiftGen (6.6.2)
+Installing SwiftLint (0.49.1)
+Installing Turf (1.2.0)
+Installing geos (7.0.0)
+Installing maplibre-pod (0.3.0)
+Installing nanopb (2.30909.0)
+Generating Pods project
+Integrating client project
+Pod installation complete! There are 24 dependencies from the Podfile and 41 total pods installed.
+
+[!] Your project does not explicitly specify the CocoaPods master specs repo. Since CDN is now used as the default, you may safely remove it from your repos directory via `pod repo remove master`. To suppress this warning please add `warn_for_unused_master_specs_repo => false` to your Podfile.
+[Pipeline] sh
++ bundle install
+Using rake 13.0.6
+Using rexml 3.2.5
+Using CFPropertyList 3.0.5
+Using public_suffix 4.0.7
+Using addressable 2.8.0
+Using artifactory 3.0.15
+Using atomos 0.1.3
+Using aws-eventstream 1.2.0
+Using aws-partitions 1.600.0
+Using aws-sigv4 1.5.0
+Using jmespath 1.6.1
+Using aws-sdk-core 3.131.1
+Using aws-sdk-kms 1.57.0
+Using aws-sdk-s3 1.114.0
+Using babosa 1.0.4
+Using bundler 2.3.16
+Using claide 1.1.0
+Using colored 1.2
+Using colored2 3.1.2
+Using colorize 0.8.1
+Using highline 2.0.3
+Using commander 4.6.0
+Using declarative 0.0.20
+Using digest-crc 0.6.4
+Using unf_ext 0.0.8.2
+Using unf 0.1.4
+Using domain_name 0.5.20190701
+Using dotenv 2.7.6
+Using emoji_regex 3.2.3
+Using excon 0.92.3
+Using faraday-em_http 1.0.0
+Using faraday-em_synchrony 1.0.0
+Using faraday-excon 1.1.0
+Using faraday-httpclient 1.0.1
+Using multipart-post 2.0.0
+Using faraday-multipart 1.0.4
+Using faraday-net_http 1.0.1
+Using faraday-net_http_persistent 1.2.0
+Using faraday-patron 1.0.0
+Using faraday-rack 1.0.0
+Using faraday-retry 1.0.3
+Using ruby2_keywords 0.0.5
+Using faraday 1.10.0
+Using http-cookie 1.0.5
+Using faraday-cookie_jar 0.0.7
+Using faraday_middleware 1.2.0
+Using fastimage 2.2.6
+Using gh_inspector 1.1.3
+Using jwt 2.4.1
+Using memoist 0.16.2
+Using multi_json 1.15.0
+Using os 1.1.4
+Using signet 0.16.1
+Using googleauth 1.1.3
+Using httpclient 2.8.3
+Using mini_mime 1.1.2
+Using trailblazer-option 0.1.2
+Using uber 0.1.0
+Using representable 3.2.0
+Using retriable 3.1.2
+Using webrick 1.7.0
+Using google-apis-core 0.6.0
+Using google-apis-androidpublisher_v3 0.22.0
+Using google-apis-playcustomapp_v1 0.9.0
+Using google-apis-iamcredentials_v1 0.12.0
+Using google-apis-storage_v1 0.15.0
+Using google-cloud-env 1.6.0
+Using google-cloud-errors 1.2.0
+Using google-cloud-core 1.6.0
+Using google-cloud-storage 1.36.2
+Using json 2.6.2
+Using mini_magick 4.11.0
+Using naturally 2.2.1
+Using optparse 0.1.1
+Using plist 3.6.0
+Using rubyzip 2.3.2
+Using security 0.1.3
+Using simctl 1.6.8
+Using terminal-notifier 2.0.0
+Using unicode-display_width 1.8.0
+Using terminal-table 1.8.0
+Using tty-screen 0.8.1
+Using tty-cursor 0.7.1
+Using tty-spinner 0.9.3
+Using word_wrap 1.0.0
+Using nanaimo 0.3.0
+Using xcodeproj 1.21.0
+Using rouge 2.0.7
+Using xcpretty 0.3.0
+Using xcpretty-travis-formatter 1.0.1
+Using fastlane 2.200.0
+Using trainer 0.9.1
+Using xctest_list 1.2.1
+Using fastlane-plugin-test_center 3.15.3
+Bundle complete! 2 Gemfile dependencies, 94 gems now installed.
+Use `bundle info [gemname]` to see where a bundled gem is installed.
+[Pipeline] sh
++ ./fastlane/executables/dependencies.sh
+10:45:10 AM [[0;32mMESSAGE[0;0m] $ pod outdated
+Updating spec repo `trunk`
+Analyzing dependencies
+The following pod updates are available:
+- Alamofire 4.9.1 -> 4.9.1 (latest version 5.6.2)
+- AlamofireImage 3.6.0 -> 3.6.0 (latest version 4.2.0)
+- BartyCrouch 4.8.0 -> 4.8.0 (latest version 4.11.0)
+- MapboxCommon 9.2.0 -> 9.2.0 (latest version 23.0.0)
+- MapboxCoreNavigation 1.4.0 -> 1.4.0 (latest version 2.7.2)
+- MapboxDirections 1.2.0 -> 1.2.0 (latest version 2.6.0)
+- MapboxNavigation 1.4.0 -> 1.4.0 (latest version 2.7.2)
+- MapboxNavigationNative 32.0.0 -> 32.0.0 (latest version 114.0.0)
+- MapboxSpeech 1.0.0 -> 1.0.0 (latest version 2.0.1)
+- PromiseKit 6.5.0 -> 6.5.0 (latest version 6.18.1)
+- Turf 1.2.0 -> 1.2.0 (latest version 2.5.0)
+
+10:45:18 AM [[0;32mMESSAGE[0;0m] $ swift outdated
+ ------------------- --------- -------- 
+  Package             Current   Latest  
+ ------------------- --------- -------- 
+  Facebook            13.2.0    14.1.0  
+  GTMSessionFetcher   1.7.2     2.1.0   
+  Nuke                10.11.2   11.1.1  
+  SkeletonView        1.30.1    1.30.2  
+  Stevia              4.8.0     5.1.2   
+ ------------------- --------- -------- 
+Ignored because of revision or branch pins: Charts, Pulley
+
+10:45:19 AM [[0;32mMESSAGE[0;0m] Outdated Dependencies: [BartyCrouch 4.8.0, MapboxCommon 9.2.0, MapboxCoreNavigation 1.4.0, MapboxDirections 1.2.0, MapboxNavigation 1.4.0, MapboxNavigationNative 32.0.0, MapboxSpeech 1.0.0, PromiseKit 6.5.0, Turf 1.2.0, Facebook 13.2.0, GTMSessionFetcher 1.7.2, Nuke 10.11.2, SkeletonView 1.30.1, Stevia 4.8.0]
+10:45:19 AM [[0;32mMESSAGE[0;0m] Summary written to: file:///Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/Bikemap-Dependencies.buildReport
+[Pipeline] }
+[Pipeline] // stage
+[Pipeline] stage
+[Pipeline] { (Running Tests)
+[Pipeline] sh
++ bundle exec fastlane sweep --verbose
+DEBUG [2022-09-08 10:45:22.82]: Checking if there are any plugins that should be loaded...
+DEBUG [2022-09-08 10:45:22.82]: Loading 'fastlane-plugin-test_center' plugin
+INFO [2022-09-08 10:45:22.82]: [32mgem 'fastlane-plugin-test_center' is already installed[0m
++-----------------------------+---------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                                                                                                                                                                                  [0;32;49mUsed plugins[0m                                                                                                                                                                                   |
++-----------------------------+---------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Plugin                      | Version | Action                                                                                                                                                                                                                                                                                                                                  |
++-----------------------------+---------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| fastlane-plugin-test_center | 3.15.3  | suppressed_tests, suppress_tests, tests_from_xcresult, suppress_tests_from_junit, tests_from_xctestrun, quit_core_simulator_service, collate_test_result_bundles, tests_from_junit, multi_scan, test_options_from_testplan, collate_html_reports, collate_junit_reports, collate_json_reports, testplans_from_scheme, collate_xcresults |
++-----------------------------+---------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+[0;33;49mSuccessfully loaded Appfile at path '/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/Appfile'[0m
+- [0;36;49mapp_identifier[0m: '[0;32;49mcom.toursprung.bikemap[0m'
+- [0;36;49mapple_id[0m: '[0;32;49mapple@bikemap.net[0m'
+- [0;36;49mteam_id[0m: '[0;32;49mG9EB5WLV5Z[0m'
+- [0;36;49mitc_team_id[0m: '[0;32;49m117700694[0m'
+-------
+INFO [2022-09-08 10:45:24.30]: [0;32;49m----------------------------------------[0m
+INFO [2022-09-08 10:45:24.30]: [0;32;49m--- Step: Verifying fastlane version ---[0m
+INFO [2022-09-08 10:45:24.30]: [0;32;49m----------------------------------------[0m
+INFO [2022-09-08 10:45:24.31]: Your fastlane version 2.200.0 matches the minimum requirement of 2.80.0  ✅
+INFO [2022-09-08 10:45:24.31]: [0;32;49m------------------------------[0m
+INFO [2022-09-08 10:45:24.31]: [0;32;49m--- Step: default_platform ---[0m
+INFO [2022-09-08 10:45:24.31]: [0;32;49m------------------------------[0m
+INFO [2022-09-08 10:45:24.31]: [0;32;49mDriving the lane 'ios sweep' 🚀[0m
+INFO [2022-09-08 10:45:24.32]: [0;32;49m------------------------[0m
+INFO [2022-09-08 10:45:24.32]: [0;32;49m--- Step: multi_scan ---[0m
+INFO [2022-09-08 10:45:24.32]: [0;32;49m------------------------[0m
+
++-------------------------+--------------------------------------------------+
+|                [0;32;49mSummary for multi_scan (test_center v3.15.3)[0m                |
++-------------------------+--------------------------------------------------+
+| try_count               | 3                                                |
+| testrun_completed_block | #<Proc:0x00007fbe86328290@Fastfile:140 (lambda)> |
++-------------------------+--------------------------------------------------+
+
+ERROR [2022-09-08 10:45:24.34]: [1;34;49mUsing deprecated option: '--custom_report_file_name' (Use `--output_files` instead)[0m
+WARN [2022-09-08 10:45:24.34]: [0;33;49mScanfile found: overriding multi_scan options with it's values.[0m
+DEBUG [2022-09-08 10:45:24.34]: Building the project in preparation for multi_scan testing
+ERROR [2022-09-08 10:45:24.35]: [1;34;49mUsing deprecated option: '--custom_report_file_name' (Use `--output_files` instead)[0m
+INFO [2022-09-08 10:45:24.35]: [0;32;49mSuccessfully loaded '/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/Scanfile' 📄[0m
+
++-------------------+------------------------+
+| Detected Values from './fastlane/Scanfile' |
++-------------------+------------------------+
+| scheme            | Bikemap                |
+| open_report       | false                  |
+| devices           | ["iPhone 8"]           |
+| clean             | false                  |
+| derived_data_path | build/DerivedData      |
+| output_types      | junit                  |
+| xcargs            | -UseNewBuildSystem=YES |
++-------------------+------------------------+
+
+WARN [2022-09-08 10:45:24.74]: [0;33;49mResolving Swift Package Manager dependencies...[0m
+INFO [2022-09-08 10:45:24.74]: [0;36;49m$ xcodebuild -resolvePackageDependencies -workspace /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/Bikemap.xcworkspace -scheme Bikemap -derivedDataPath build/DerivedData[0m
+INFO [2022-09-08 10:45:25.47]: ▸ [0;35;49mCommand line invocation:[0m
+INFO [2022-09-08 10:45:25.47]: ▸ [0;35;49m    /Applications/Xcode-beta.app/Contents/Developer/usr/bin/xcodebuild -resolvePackageDependencies -workspace /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/Bikemap.xcworkspace -scheme Bikemap -derivedDataPath build/DerivedData[0m
+INFO [2022-09-08 10:45:25.47]: ▸ [0;35;49mUser defaults from command line:[0m
+INFO [2022-09-08 10:45:25.47]: ▸ [0;35;49m    IDEDerivedDataPathOverride = /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData[0m
+INFO [2022-09-08 10:45:25.47]: ▸ [0;35;49m    IDEPackageSupportUseBuiltinSCM = YES[0m
+INFO [2022-09-08 10:45:26.69]: ▸ [0;35;49mResolve Package Graph[0m
+INFO [2022-09-08 10:45:27.54]: ▸ [0;35;49mFetching from https://github.com/maparoni/Charts (cached)[0m
+INFO [2022-09-08 10:45:28.96]: ▸ [0;35;49mFetching from https://github.com/bikemap/Pulley (cached)[0m
+INFO [2022-09-08 10:45:30.08]: ▸ [0;35;49mFetching from https://github.com/google/GTMAppAuth.git (cached)[0m
+INFO [2022-09-08 10:45:31.92]: ▸ [0;35;49mFetching from https://github.com/google/GoogleSignIn-iOS.git (cached)[0m
+INFO [2022-09-08 10:45:39.84]: ▸ [0;35;49mFetching from https://github.com/google/promises.git (cached)[0m
+INFO [2022-09-08 10:45:39.84]: ▸ [0;35;49mFetching from https://github.com/utahiosmac/Marshal.git (cached)[0m
+INFO [2022-09-08 10:45:39.84]: ▸ [0;35;49mFetching from https://github.com/apple/swift-numerics (cached)[0m
+INFO [2022-09-08 10:45:39.84]: ▸ [0;35;49mFetching from https://github.com/kean/Nuke.git (cached)[0m
+INFO [2022-09-08 10:45:42.11]: ▸ [0;35;49mFetching from https://github.com/google/gtm-session-fetcher.git (cached)[0m
+INFO [2022-09-08 10:45:42.11]: ▸ [0;35;49mFetching from https://github.com/apple/swift-algorithms.git (cached)[0m
+INFO [2022-09-08 10:45:42.11]: ▸ [0;35;49mFetching from https://github.com/kaishin/Gifu (cached)[0m
+INFO [2022-09-08 10:45:42.11]: ▸ [0;35;49mFetching from https://github.com/weichsel/ZIPFoundation.git (cached)[0m
+INFO [2022-09-08 10:45:42.11]: ▸ [0;35;49mFetching from https://github.com/hactar/swiftui-visual-effects.git (cached)[0m
+INFO [2022-09-08 10:45:42.11]: ▸ [0;35;49mFetching from https://github.com/kishikawakatsumi/KeychainAccess.git (cached)[0m
+INFO [2022-09-08 10:45:42.11]: ▸ [0;35;49mFetching from https://github.com/openid/AppAuth-iOS.git (cached)[0m
+INFO [2022-09-08 10:45:43.16]: ▸ [0;35;49mFetching from https://github.com/Yummypets/YPImagePicker.git (cached)[0m
+INFO [2022-09-08 10:45:44.11]: ▸ [0;35;49mFetching from https://github.com/jpsim/Yams.git (cached)[0m
+INFO [2022-09-08 10:45:44.11]: ▸ [0;35;49mFetching from https://github.com/Juanpe/SkeletonView.git (cached)[0m
+INFO [2022-09-08 10:45:45.57]: ▸ [0;35;49mFetching from https://github.com/vincentneo/CoreGPX.git (cached)[0m
+INFO [2022-09-08 10:45:45.57]: ▸ [0;35;49mFetching from https://github.com/facebook/facebook-ios-sdk.git (cached)[0m
+INFO [2022-09-08 10:45:48.69]: ▸ [0;35;49mFetching from https://github.com/jdg/MBProgressHUD.git (cached)[0m
+INFO [2022-09-08 10:45:48.69]: ▸ [0;35;49mFetching from https://github.com/kean/NukeUI.git (cached)[0m
+INFO [2022-09-08 10:45:48.69]: ▸ [0;35;49mFetching from https://github.com/ElaWorkshop/TagListView.git (cached)[0m
+INFO [2022-09-08 10:45:48.69]: ▸ [0;35;49mFetching from https://github.com/google/GoogleUtilities.git (cached)[0m
+INFO [2022-09-08 10:45:48.69]: ▸ [0;35;49mFetching from https://github.com/HHK1/PryntTrimmerView (cached)[0m
+INFO [2022-09-08 10:45:48.69]: ▸ [0;35;49mFetching from https://github.com/freshOS/Stevia (cached)[0m
+INFO [2022-09-08 10:46:06.70]: ▸ [0;35;49mCloning local copy of package ‘GoogleUtilities’[0m
+INFO [2022-09-08 10:46:06.74]: ▸ [0;35;49mChecking out 7.7.1 of package ‘GoogleUtilities’[0m
+INFO [2022-09-08 10:46:06.95]: ▸ [0;35;49mCloning local copy of package ‘swiftui-visual-effects’[0m
+INFO [2022-09-08 10:46:06.98]: ▸ [0;35;49mChecking out 1.0.4 of package ‘swiftui-visual-effects’[0m
+INFO [2022-09-08 10:46:07.12]: ▸ [0;35;49mCloning local copy of package ‘Nuke’[0m
+INFO [2022-09-08 10:46:07.18]: ▸ [0;35;49mChecking out 10.11.2 of package ‘Nuke’[0m
+INFO [2022-09-08 10:46:07.42]: ▸ [0;35;49mCloning local copy of package ‘facebook-ios-sdk’[0m
+INFO [2022-09-08 10:46:07.47]: ▸ [0;35;49mChecking out 13.2.0 of package ‘facebook-ios-sdk’[0m
+INFO [2022-09-08 10:46:08.34]: ▸ [0;35;49mCloning local copy of package ‘PryntTrimmerView’[0m
+INFO [2022-09-08 10:46:08.37]: ▸ [0;35;49mChecking out 4.0.2 of package ‘PryntTrimmerView’[0m
+INFO [2022-09-08 10:46:08.54]: ▸ [0;35;49mCloning local copy of package ‘Gifu’[0m
+INFO [2022-09-08 10:46:08.57]: ▸ [0;35;49mChecking out 3.3.1 of package ‘Gifu’[0m
+INFO [2022-09-08 10:46:09.00]: ▸ [0;35;49mCloning local copy of package ‘NukeUI’[0m
+INFO [2022-09-08 10:46:09.03]: ▸ [0;35;49mChecking out 0.8.3 of package ‘NukeUI’[0m
+INFO [2022-09-08 10:46:09.16]: ▸ [0;35;49mCloning local copy of package ‘GTMAppAuth’[0m
+INFO [2022-09-08 10:46:09.19]: ▸ [0;35;49mChecking out 1.3.0 of package ‘GTMAppAuth’[0m
+INFO [2022-09-08 10:46:09.34]: ▸ [0;35;49mCloning local copy of package ‘GoogleSignIn-iOS’[0m
+INFO [2022-09-08 10:46:09.40]: ▸ [0;35;49mChecking out 6.2.3 of package ‘GoogleSignIn-iOS’[0m
+INFO [2022-09-08 10:46:09.64]: ▸ [0;35;49mCloning local copy of package ‘swift-numerics’[0m
+INFO [2022-09-08 10:46:09.67]: ▸ [0;35;49mChecking out 1.0.2 of package ‘swift-numerics’[0m
+INFO [2022-09-08 10:46:09.82]: ▸ [0;35;49mCloning local copy of package ‘KeychainAccess’[0m
+INFO [2022-09-08 10:46:09.85]: ▸ [0;35;49mChecking out 4.2.2 of package ‘KeychainAccess’[0m
+INFO [2022-09-08 10:46:10.02]: ▸ [0;35;49mCloning local copy of package ‘CoreGPX’[0m
+INFO [2022-09-08 10:46:10.06]: ▸ [0;35;49mChecking out 0.9.0 of package ‘CoreGPX’[0m
+INFO [2022-09-08 10:46:10.28]: ▸ [0;35;49mCloning local copy of package ‘SkeletonView’[0m
+INFO [2022-09-08 10:46:10.32]: ▸ [0;35;49mChecking out 1.30.1 of package ‘SkeletonView’[0m
+INFO [2022-09-08 10:46:10.59]: ▸ [0;35;49mCloning local copy of package ‘gtm-session-fetcher’[0m
+INFO [2022-09-08 10:46:10.62]: ▸ [0;35;49mChecking out 1.7.2 of package ‘gtm-session-fetcher’[0m
+INFO [2022-09-08 10:46:10.79]: ▸ [0;35;49mCloning local copy of package ‘Marshal’[0m
+INFO [2022-09-08 10:46:10.82]: ▸ [0;35;49mChecking out 1.2.8 of package ‘Marshal’[0m
+INFO [2022-09-08 10:46:10.99]: ▸ [0;35;49mCloning local copy of package ‘ZIPFoundation’[0m
+INFO [2022-09-08 10:46:11.02]: ▸ [0;35;49mChecking out 0.9.14 of package ‘ZIPFoundation’[0m
+INFO [2022-09-08 10:46:11.34]: ▸ [0;35;49mCloning local copy of package ‘TagListView’[0m
+INFO [2022-09-08 10:46:11.37]: ▸ [0;35;49mChecking out 1.4.1 of package ‘TagListView’[0m
+INFO [2022-09-08 10:46:11.49]: ▸ [0;35;49mCloning local copy of package ‘swift-algorithms’[0m
+INFO [2022-09-08 10:46:11.52]: ▸ [0;35;49mChecking out 1.0.0 of package ‘swift-algorithms’[0m
+INFO [2022-09-08 10:46:11.66]: ▸ [0;35;49mCloning local copy of package ‘Charts’[0m
+INFO [2022-09-08 10:46:11.69]: ▸ [0;35;49mChecking out xcode14 of package ‘Charts’[0m
+INFO [2022-09-08 10:46:12.20]: ▸ [0;35;49mCloning local copy of package ‘YPImagePicker’[0m
+INFO [2022-09-08 10:46:12.23]: ▸ [0;35;49mChecking out 5.2.1 of package ‘YPImagePicker’[0m
+INFO [2022-09-08 10:46:12.50]: ▸ [0;35;49mCloning local copy of package ‘promises’[0m
+INFO [2022-09-08 10:46:12.53]: ▸ [0;35;49mChecking out 2.1.1 of package ‘promises’[0m
+INFO [2022-09-08 10:46:12.71]: ▸ [0;35;49mCloning local copy of package ‘AppAuth-iOS’[0m
+INFO [2022-09-08 10:46:12.74]: ▸ [0;35;49mChecking out 1.5.0 of package ‘AppAuth-iOS’[0m
+INFO [2022-09-08 10:46:13.00]: ▸ [0;35;49mCloning local copy of package ‘Yams’[0m
+INFO [2022-09-08 10:46:13.04]: ▸ [0;35;49mChecking out 5.0.1 of package ‘Yams’[0m
+INFO [2022-09-08 10:46:13.22]: ▸ [0;35;49mCloning local copy of package ‘MBProgressHUD’[0m
+INFO [2022-09-08 10:46:13.25]: ▸ [0;35;49mChecking out 1.2.0 of package ‘MBProgressHUD’[0m
+INFO [2022-09-08 10:46:13.41]: ▸ [0;35;49mCloning local copy of package ‘Pulley’[0m
+INFO [2022-09-08 10:46:13.43]: ▸ [0;35;49mChecking out enhancement/add-set-drawer-complition-delegate of package ‘Pulley’[0m
+INFO [2022-09-08 10:46:13.58]: ▸ [0;35;49mCloning local copy of package ‘Stevia’[0m
+INFO [2022-09-08 10:46:13.61]: ▸ [0;35;49mChecking out 4.8.0 of package ‘Stevia’[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49mResolved source packages:[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  Stevia: https://github.com/freshOS/Stevia @ 4.8.0[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  CoreGPX: https://github.com/vincentneo/CoreGPX.git @ 0.9.0[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  Promises: https://github.com/google/promises.git @ 2.1.1[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  Nuke: https://github.com/kean/Nuke.git @ 10.11.2[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  Yams: https://github.com/jpsim/Yams.git @ 5.0.1[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  GTMSessionFetcher: https://github.com/google/gtm-session-fetcher.git @ 1.7.2[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  SkeletonView: https://github.com/Juanpe/SkeletonView.git @ 1.30.1[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  Gifu: https://github.com/kaishin/Gifu @ 3.3.1[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  AppAuth: https://github.com/openid/AppAuth-iOS.git @ 1.5.0[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  GoogleUtilities: https://github.com/google/GoogleUtilities.git @ 7.7.1[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  GoogleSignIn: https://github.com/google/GoogleSignIn-iOS.git @ 6.2.3[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  swift-numerics: https://github.com/apple/swift-numerics @ 1.0.2[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  MBProgressHUD: https://github.com/jdg/MBProgressHUD.git @ 1.2.0[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  Pulley: https://github.com/bikemap/Pulley @ enhancement/add-set-drawer-complition-delegate[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  Charts: https://github.com/maparoni/Charts @ xcode14[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  NukeUI: https://github.com/kean/NukeUI.git @ 0.8.3[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  swift-algorithms: https://github.com/apple/swift-algorithms.git @ 1.0.0[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  BikemapCore: /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/BikemapCore[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  PryntTrimmerView: https://github.com/HHK1/PryntTrimmerView @ 4.0.2[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  TagListView: https://github.com/ElaWorkshop/TagListView.git @ 1.4.1[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  YPImagePicker: https://github.com/Yummypets/YPImagePicker.git @ 5.2.1[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  Facebook: https://github.com/facebook/facebook-ios-sdk.git @ 13.2.0[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  SwiftUIVisualEffects: https://github.com/hactar/swiftui-visual-effects.git @ 1.0.4[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  Marshal: https://github.com/utahiosmac/Marshal.git @ 1.2.8[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  GTMAppAuth: https://github.com/google/GTMAppAuth.git @ 1.3.0[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  KeychainAccess: https://github.com/kishikawakatsumi/KeychainAccess.git @ 4.2.2[0m
+INFO [2022-09-08 10:46:23.15]: ▸ [0;35;49m  ZIPFoundation: https://github.com/weichsel/ZIPFoundation.git @ 0.9.14[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m--- xcodebuild: WARNING: Using the first of multiple matching destinations:[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Any iOS Simulator Device }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:E745FF0A-AE32-4219-A549-E54506628E5E, OS:15.5, name:iPad (9th generation) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:066C4E6F-15F7-4B69-9CD6-D223F0DC7BD5, OS:16.0, name:iPad (9th generation) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:9956C560-0CCE-445D-A1A4-ADEBDCFD3F62, OS:15.5, name:iPad Air (5th generation) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:5EBF3EFF-74CF-4AF6-8BC3-4B5D5541E3F9, OS:16.0, name:iPad Air (5th generation) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:5E14F069-2DBE-4A60-A3FB-721A643AACD4, OS:15.5, name:iPad Pro (9.7-inch) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:CD716C3C-76A4-450F-8C70-F8785DE7A5EC, OS:16.0, name:iPad Pro (9.7-inch) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:BB69670E-4271-44A1-BA44-E99658423E13, OS:15.5, name:iPad Pro (11-inch) (3rd generation) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:AD049621-D739-4345-B99C-F34C97D86004, OS:16.0, name:iPad Pro (11-inch) (3rd generation) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:33FFB1F6-1D91-4CCD-A67C-3906658C155B, OS:15.5, name:iPad Pro (12.9-inch) (5th generation) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:68F1C21C-FAAF-41CC-84A1-993186736143, OS:16.0, name:iPad Pro (12.9-inch) (5th generation) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:F9C555AC-6D35-4F8E-AA73-C9CE43125602, OS:15.5, name:iPad mini (6th generation) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:D838D789-F5B1-4994-BA02-4DBE6E8B8CA0, OS:16.0, name:iPad mini (6th generation) }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E, OS:15.5, name:iPhone 8 }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:084E09FC-87DA-4B77-AC9A-9B16F05B355D, OS:15.5, name:iPhone 8 Plus }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:2CEFEC63-66C1-402D-94F6-63602E3EAC50, OS:16.0, name:iPhone 8 Plus }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:ACB42395-B9FC-4BB7-8088-91D2CB8E58F2, OS:15.5, name:iPhone 11 }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:0D116A7A-998C-48F9-9A65-D0776AAAB8E1, OS:16.0, name:iPhone 11 }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:6B7EF25A-75DF-45F6-9705-041220CAF493, OS:15.5, name:iPhone 11 Pro }[0m
+INFO [2022-09-08 10:46:23.18]: ▸ [0;35;49m{ platform:iOS Simulator, id:CEF1EBC9-BA32-45AB-9C30-75F6D3B6D4C6, OS:16.0, name:iPhone 11 Pro }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:E5778643-E3AB-4B69-9097-9B0B6EEB20F0, OS:15.5, name:iPhone 11 Pro Max }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:1773EEED-8F6F-4147-B37E-12632FCDC312, OS:16.0, name:iPhone 11 Pro Max }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:5C84097E-BBD5-4AD2-A37D-05CA60671E55, OS:15.5, name:iPhone 12 }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:3529A54C-7519-45CA-8779-47C19666CC67, OS:16.0, name:iPhone 12 }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:21461DA3-E122-4105-92AF-D817E32D2775, OS:15.5, name:iPhone 12 Pro }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:28FCA4EB-B91C-4CE1-B75F-411EBE9479D6, OS:16.0, name:iPhone 12 Pro }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:1AD06C8C-7495-47B5-8454-9714230DA258, OS:15.5, name:iPhone 12 Pro Max }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:D1A617CE-5A57-4F25-93E1-C2B9B1FC6409, OS:16.0, name:iPhone 12 Pro Max }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:9D6EEDFC-A7D0-4AC6-A9EA-9434CAB1DB70, OS:15.5, name:iPhone 12 mini }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:C03F34F2-422B-40C2-A5DC-3481F4FA5493, OS:16.0, name:iPhone 12 mini }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:4CF39742-EB3D-4224-870E-8AD082B6BAC2, OS:15.5, name:iPhone 13 }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:1E4C27CC-62B2-40EE-8D66-A6BB3F28DCF4, OS:16.0, name:iPhone 13 }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:49F03216-24A3-47EA-8144-B0556C447457, OS:15.5, name:iPhone 13 Pro }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:7920F7BF-B831-4D66-A315-37E2F76E076E, OS:16.0, name:iPhone 13 Pro }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:FFFB3CBC-24A3-4772-99CE-2107EC3B91CF, OS:15.5, name:iPhone 13 Pro Max }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:4FEE3768-28BA-4DC4-B03B-0117A0510467, OS:16.0, name:iPhone 13 Pro Max }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:15609DF4-6D8C-4B77-97A7-017AEDBB82EC, OS:15.5, name:iPhone 13 mini }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:2D3DC8EF-DC4E-4CBC-B003-25125ECF55ED, OS:16.0, name:iPhone 13 mini }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:E4C6E24E-B320-4018-9164-57B2641C0B0F, OS:15.5, name:iPhone SE (3rd generation) }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:8CBFF3A2-9FA1-4E9E-A2EA-91F9DC6EDE1D, OS:16.0, name:iPhone SE (3rd generation) }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49m{ platform:iOS Simulator, id:3279AD2D-9358-4142-A45D-C47E81538069, OS:15.5, name:iPod touch (7th generation) }[0m
+INFO [2022-09-08 10:46:23.19]: ▸ [0;35;49mresolved source packages: Stevia, CoreGPX, Promises, Nuke, Yams, GTMSessionFetcher, SkeletonView, Gifu, AppAuth, GoogleUtilities, GoogleSignIn, swift-numerics, MBProgressHUD, Pulley, Charts, NukeUI, swift-algorithms, BikemapCore, PryntTrimmerView, TagListView, YPImagePicker, Facebook, SwiftUIVisualEffects, Marshal, GTMAppAuth, KeychainAccess, ZIPFoundation[0m
+INFO [2022-09-08 10:46:23.22]: [0;36;49m$ xcodebuild -showBuildSettings -workspace /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/Bikemap.xcworkspace -scheme Bikemap -derivedDataPath build/DerivedData[0m
+WARN [2022-09-08 10:46:26.24]: [0;33;49mCommand timed out after 3 seconds on try 1 of 4, trying again with a 6 second timeout...[0m
+--- xcodebuild: WARNING: Using the first of multiple matching destinations:
+{ platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
+{ platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Any iOS Simulator Device }
+{ platform:iOS Simulator, id:E745FF0A-AE32-4219-A549-E54506628E5E, OS:15.5, name:iPad (9th generation) }
+{ platform:iOS Simulator, id:066C4E6F-15F7-4B69-9CD6-D223F0DC7BD5, OS:16.0, name:iPad (9th generation) }
+{ platform:iOS Simulator, id:9956C560-0CCE-445D-A1A4-ADEBDCFD3F62, OS:15.5, name:iPad Air (5th generation) }
+{ platform:iOS Simulator, id:5EBF3EFF-74CF-4AF6-8BC3-4B5D5541E3F9, OS:16.0, name:iPad Air (5th generation) }
+{ platform:iOS Simulator, id:5E14F069-2DBE-4A60-A3FB-721A643AACD4, OS:15.5, name:iPad Pro (9.7-inch) }
+{ platform:iOS Simulator, id:CD716C3C-76A4-450F-8C70-F8785DE7A5EC, OS:16.0, name:iPad Pro (9.7-inch) }
+{ platform:iOS Simulator, id:BB69670E-4271-44A1-BA44-E99658423E13, OS:15.5, name:iPad Pro (11-inch) (3rd generation) }
+{ platform:iOS Simulator, id:AD049621-D739-4345-B99C-F34C97D86004, OS:16.0, name:iPad Pro (11-inch) (3rd generation) }
+{ platform:iOS Simulator, id:33FFB1F6-1D91-4CCD-A67C-3906658C155B, OS:15.5, name:iPad Pro (12.9-inch) (5th generation) }
+{ platform:iOS Simulator, id:68F1C21C-FAAF-41CC-84A1-993186736143, OS:16.0, name:iPad Pro (12.9-inch) (5th generation) }
+{ platform:iOS Simulator, id:F9C555AC-6D35-4F8E-AA73-C9CE43125602, OS:15.5, name:iPad mini (6th generation) }
+{ platform:iOS Simulator, id:D838D789-F5B1-4994-BA02-4DBE6E8B8CA0, OS:16.0, name:iPad mini (6th generation) }
+{ platform:iOS Simulator, id:D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E, OS:15.5, name:iPhone 8 }
+{ platform:iOS Simulator, id:084E09FC-87DA-4B77-AC9A-9B16F05B355D, OS:15.5, name:iPhone 8 Plus }
+{ platform:iOS Simulator, id:2CEFEC63-66C1-402D-94F6-63602E3EAC50, OS:16.0, name:iPhone 8 Plus }
+{ platform:iOS Simulator, id:ACB42395-B9FC-4BB7-8088-91D2CB8E58F2, OS:15.5, name:iPhone 11 }
+{ platform:iOS Simulator, id:0D116A7A-998C-48F9-9A65-D0776AAAB8E1, OS:16.0, name:iPhone 11 }
+{ platform:iOS Simulator, id:6B7EF25A-75DF-45F6-9705-041220CAF493, OS:15.5, name:iPhone 11 Pro }
+{ platform:iOS Simulator, id:CEF1EBC9-BA32-45AB-9C30-75F6D3B6D4C6, OS:16.0, name:iPhone 11 Pro }
+{ platform:iOS Simulator, id:E5778643-E3AB-4B69-9097-9B0B6EEB20F0, OS:15.5, name:iPhone 11 Pro Max }
+{ platform:iOS Simulator, id:1773EEED-8F6F-4147-B37E-12632FCDC312, OS:16.0, name:iPhone 11 Pro Max }
+{ platform:iOS Simulator, id:5C84097E-BBD5-4AD2-A37D-05CA60671E55, OS:15.5, name:iPhone 12 }
+{ platform:iOS Simulator, id:3529A54C-7519-45CA-8779-47C19666CC67, OS:16.0, name:iPhone 12 }
+{ platform:iOS Simulator, id:21461DA3-E122-4105-92AF-D817E32D2775, OS:15.5, name:iPhone 12 Pro }
+{ platform:iOS Simulator, id:28FCA4EB-B91C-4CE1-B75F-411EBE9479D6, OS:16.0, name:iPhone 12 Pro }
+{ platform:iOS Simulator, id:1AD06C8C-7495-47B5-8454-9714230DA258, OS:15.5, name:iPhone 12 Pro Max }
+{ platform:iOS Simulator, id:D1A617CE-5A57-4F25-93E1-C2B9B1FC6409, OS:16.0, name:iPhone 12 Pro Max }
+{ platform:iOS Simulator, id:9D6EEDFC-A7D0-4AC6-A9EA-9434CAB1DB70, OS:15.5, name:iPhone 12 mini }
+{ platform:iOS Simulator, id:C03F34F2-422B-40C2-A5DC-3481F4FA5493, OS:16.0, name:iPhone 12 mini }
+{ platform:iOS Simulator, id:4CF39742-EB3D-4224-870E-8AD082B6BAC2, OS:15.5, name:iPhone 13 }
+{ platform:iOS Simulator, id:1E4C27CC-62B2-40EE-8D66-A6BB3F28DCF4, OS:16.0, name:iPhone 13 }
+{ platform:iOS Simulator, id:49F03216-24A3-47EA-8144-B0556C447457, OS:15.5, name:iPhone 13 Pro }
+{ platform:iOS Simulator, id:7920F7BF-B831-4D66-A315-37E2F76E076E, OS:16.0, name:iPhone 13 Pro }
+{ platform:iOS Simulator, id:FFFB3CBC-24A3-4772-99CE-2107EC3B91CF, OS:15.5, name:iPhone 13 Pro Max }
+{ platform:iOS Simulator, id:4FEE3768-28BA-4DC4-B03B-0117A0510467, OS:16.0, name:iPhone 13 Pro Max }
+{ platform:iOS Simulator, id:15609DF4-6D8C-4B77-97A7-017AEDBB82EC, OS:15.5, name:iPhone 13 mini }
+{ platform:iOS Simulator, id:2D3DC8EF-DC4E-4CBC-B003-25125ECF55ED, OS:16.0, name:iPhone 13 mini }
+{ platform:iOS Simulator, id:E4C6E24E-B320-4018-9164-57B2641C0B0F, OS:15.5, name:iPhone SE (3rd generation) }
+{ platform:iOS Simulator, id:8CBFF3A2-9FA1-4E9E-A2EA-91F9DC6EDE1D, OS:16.0, name:iPhone SE (3rd generation) }
+{ platform:iOS Simulator, id:3279AD2D-9358-4142-A45D-C47E81538069, OS:15.5, name:iPod touch (7th generation) }
+--- xcodebuild: WARNING: Using the first of multiple matching destinations:
+{ platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
+{ platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Any iOS Simulator Device }
+{ platform:iOS Simulator, id:E745FF0A-AE32-4219-A549-E54506628E5E, OS:15.5, name:iPad (9th generation) }
+{ platform:iOS Simulator, id:066C4E6F-15F7-4B69-9CD6-D223F0DC7BD5, OS:16.0, name:iPad (9th generation) }
+{ platform:iOS Simulator, id:9956C560-0CCE-445D-A1A4-ADEBDCFD3F62, OS:15.5, name:iPad Air (5th generation) }
+{ platform:iOS Simulator, id:5EBF3EFF-74CF-4AF6-8BC3-4B5D5541E3F9, OS:16.0, name:iPad Air (5th generation) }
+{ platform:iOS Simulator, id:5E14F069-2DBE-4A60-A3FB-721A643AACD4, OS:15.5, name:iPad Pro (9.7-inch) }
+{ platform:iOS Simulator, id:CD716C3C-76A4-450F-8C70-F8785DE7A5EC, OS:16.0, name:iPad Pro (9.7-inch) }
+{ platform:iOS Simulator, id:BB69670E-4271-44A1-BA44-E99658423E13, OS:15.5, name:iPad Pro (11-inch) (3rd generation) }
+{ platform:iOS Simulator, id:AD049621-D739-4345-B99C-F34C97D86004, OS:16.0, name:iPad Pro (11-inch) (3rd generation) }
+{ platform:iOS Simulator, id:33FFB1F6-1D91-4CCD-A67C-3906658C155B, OS:15.5, name:iPad Pro (12.9-inch) (5th generation) }
+{ platform:iOS Simulator, id:68F1C21C-FAAF-41CC-84A1-993186736143, OS:16.0, name:iPad Pro (12.9-inch) (5th generation) }
+{ platform:iOS Simulator, id:F9C555AC-6D35-4F8E-AA73-C9CE43125602, OS:15.5, name:iPad mini (6th generation) }
+{ platform:iOS Simulator, id:D838D789-F5B1-4994-BA02-4DBE6E8B8CA0, OS:16.0, name:iPad mini (6th generation) }
+{ platform:iOS Simulator, id:D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E, OS:15.5, name:iPhone 8 }
+{ platform:iOS Simulator, id:084E09FC-87DA-4B77-AC9A-9B16F05B355D, OS:15.5, name:iPhone 8 Plus }
+{ platform:iOS Simulator, id:2CEFEC63-66C1-402D-94F6-63602E3EAC50, OS:16.0, name:iPhone 8 Plus }
+{ platform:iOS Simulator, id:ACB42395-B9FC-4BB7-8088-91D2CB8E58F2, OS:15.5, name:iPhone 11 }
+{ platform:iOS Simulator, id:0D116A7A-998C-48F9-9A65-D0776AAAB8E1, OS:16.0, name:iPhone 11 }
+{ platform:iOS Simulator, id:6B7EF25A-75DF-45F6-9705-041220CAF493, OS:15.5, name:iPhone 11 Pro }
+{ platform:iOS Simulator, id:CEF1EBC9-BA32-45AB-9C30-75F6D3B6D4C6, OS:16.0, name:iPhone 11 Pro }
+{ platform:iOS Simulator, id:E5778643-E3AB-4B69-9097-9B0B6EEB20F0, OS:15.5, name:iPhone 11 Pro Max }
+{ platform:iOS Simulator, id:1773EEED-8F6F-4147-B37E-12632FCDC312, OS:16.0, name:iPhone 11 Pro Max }
+{ platform:iOS Simulator, id:5C84097E-BBD5-4AD2-A37D-05CA60671E55, OS:15.5, name:iPhone 12 }
+{ platform:iOS Simulator, id:3529A54C-7519-45CA-8779-47C19666CC67, OS:16.0, name:iPhone 12 }
+{ platform:iOS Simulator, id:21461DA3-E122-4105-92AF-D817E32D2775, OS:15.5, name:iPhone 12 Pro }
+{ platform:iOS Simulator, id:28FCA4EB-B91C-4CE1-B75F-411EBE9479D6, OS:16.0, name:iPhone 12 Pro }
+{ platform:iOS Simulator, id:1AD06C8C-7495-47B5-8454-9714230DA258, OS:15.5, name:iPhone 12 Pro Max }
+{ platform:iOS Simulator, id:D1A617CE-5A57-4F25-93E1-C2B9B1FC6409, OS:16.0, name:iPhone 12 Pro Max }
+{ platform:iOS Simulator, id:9D6EEDFC-A7D0-4AC6-A9EA-9434CAB1DB70, OS:15.5, name:iPhone 12 mini }
+{ platform:iOS Simulator, id:C03F34F2-422B-40C2-A5DC-3481F4FA5493, OS:16.0, name:iPhone 12 mini }
+{ platform:iOS Simulator, id:4CF39742-EB3D-4224-870E-8AD082B6BAC2, OS:15.5, name:iPhone 13 }
+{ platform:iOS Simulator, id:1E4C27CC-62B2-40EE-8D66-A6BB3F28DCF4, OS:16.0, name:iPhone 13 }
+{ platform:iOS Simulator, id:49F03216-24A3-47EA-8144-B0556C447457, OS:15.5, name:iPhone 13 Pro }
+{ platform:iOS Simulator, id:7920F7BF-B831-4D66-A315-37E2F76E076E, OS:16.0, name:iPhone 13 Pro }
+{ platform:iOS Simulator, id:FFFB3CBC-24A3-4772-99CE-2107EC3B91CF, OS:15.5, name:iPhone 13 Pro Max }
+{ platform:iOS Simulator, id:4FEE3768-28BA-4DC4-B03B-0117A0510467, OS:16.0, name:iPhone 13 Pro Max }
+{ platform:iOS Simulator, id:15609DF4-6D8C-4B77-97A7-017AEDBB82EC, OS:15.5, name:iPhone 13 mini }
+{ platform:iOS Simulator, id:2D3DC8EF-DC4E-4CBC-B003-25125ECF55ED, OS:16.0, name:iPhone 13 mini }
+{ platform:iOS Simulator, id:E4C6E24E-B320-4018-9164-57B2641C0B0F, OS:15.5, name:iPhone SE (3rd generation) }
+{ platform:iOS Simulator, id:8CBFF3A2-9FA1-4E9E-A2EA-91F9DC6EDE1D, OS:16.0, name:iPhone SE (3rd generation) }
+{ platform:iOS Simulator, id:3279AD2D-9358-4142-A45D-C47E81538069, OS:15.5, name:iPod touch (7th generation) }
+2022-09-08 10:46:30.513 xcodebuild[38118:21320830] Requested but did not find extension point with identifier Xcode.InterfaceBuilderBuildSupport.PlatformDefinition
+WARN [2022-09-08 10:46:32.24]: [0;33;49mCommand timed out after 6 seconds on try 2 of 4, trying again with a 12 second timeout...[0m
+2022-09-08 10:46:33.054 xcodebuild[38133:21320933] Requested but did not find extension point with identifier Xcode.InterfaceBuilderBuildSupport.PlatformDefinition
+--- xcodebuild: WARNING: Using the first of multiple matching destinations:
+{ platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
+{ platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Any iOS Simulator Device }
+{ platform:iOS Simulator, id:E745FF0A-AE32-4219-A549-E54506628E5E, OS:15.5, name:iPad (9th generation) }
+{ platform:iOS Simulator, id:066C4E6F-15F7-4B69-9CD6-D223F0DC7BD5, OS:16.0, name:iPad (9th generation) }
+{ platform:iOS Simulator, id:9956C560-0CCE-445D-A1A4-ADEBDCFD3F62, OS:15.5, name:iPad Air (5th generation) }
+{ platform:iOS Simulator, id:5EBF3EFF-74CF-4AF6-8BC3-4B5D5541E3F9, OS:16.0, name:iPad Air (5th generation) }
+{ platform:iOS Simulator, id:5E14F069-2DBE-4A60-A3FB-721A643AACD4, OS:15.5, name:iPad Pro (9.7-inch) }
+{ platform:iOS Simulator, id:CD716C3C-76A4-450F-8C70-F8785DE7A5EC, OS:16.0, name:iPad Pro (9.7-inch) }
+{ platform:iOS Simulator, id:BB69670E-4271-44A1-BA44-E99658423E13, OS:15.5, name:iPad Pro (11-inch) (3rd generation) }
+{ platform:iOS Simulator, id:AD049621-D739-4345-B99C-F34C97D86004, OS:16.0, name:iPad Pro (11-inch) (3rd generation) }
+{ platform:iOS Simulator, id:33FFB1F6-1D91-4CCD-A67C-3906658C155B, OS:15.5, name:iPad Pro (12.9-inch) (5th generation) }
+{ platform:iOS Simulator, id:68F1C21C-FAAF-41CC-84A1-993186736143, OS:16.0, name:iPad Pro (12.9-inch) (5th generation) }
+{ platform:iOS Simulator, id:F9C555AC-6D35-4F8E-AA73-C9CE43125602, OS:15.5, name:iPad mini (6th generation) }
+{ platform:iOS Simulator, id:D838D789-F5B1-4994-BA02-4DBE6E8B8CA0, OS:16.0, name:iPad mini (6th generation) }
+{ platform:iOS Simulator, id:D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E, OS:15.5, name:iPhone 8 }
+{ platform:iOS Simulator, id:084E09FC-87DA-4B77-AC9A-9B16F05B355D, OS:15.5, name:iPhone 8 Plus }
+{ platform:iOS Simulator, id:2CEFEC63-66C1-402D-94F6-63602E3EAC50, OS:16.0, name:iPhone 8 Plus }
+{ platform:iOS Simulator, id:ACB42395-B9FC-4BB7-8088-91D2CB8E58F2, OS:15.5, name:iPhone 11 }
+{ platform:iOS Simulator, id:0D116A7A-998C-48F9-9A65-D0776AAAB8E1, OS:16.0, name:iPhone 11 }
+{ platform:iOS Simulator, id:6B7EF25A-75DF-45F6-9705-041220CAF493, OS:15.5, name:iPhone 11 Pro }
+{ platform:iOS Simulator, id:CEF1EBC9-BA32-45AB-9C30-75F6D3B6D4C6, OS:16.0, name:iPhone 11 Pro }
+{ platform:iOS Simulator, id:E5778643-E3AB-4B69-9097-9B0B6EEB20F0, OS:15.5, name:iPhone 11 Pro Max }
+{ platform:iOS Simulator, id:1773EEED-8F6F-4147-B37E-12632FCDC312, OS:16.0, name:iPhone 11 Pro Max }
+{ platform:iOS Simulator, id:5C84097E-BBD5-4AD2-A37D-05CA60671E55, OS:15.5, name:iPhone 12 }
+{ platform:iOS Simulator, id:3529A54C-7519-45CA-8779-47C19666CC67, OS:16.0, name:iPhone 12 }
+{ platform:iOS Simulator, id:21461DA3-E122-4105-92AF-D817E32D2775, OS:15.5, name:iPhone 12 Pro }
+{ platform:iOS Simulator, id:28FCA4EB-B91C-4CE1-B75F-411EBE9479D6, OS:16.0, name:iPhone 12 Pro }
+{ platform:iOS Simulator, id:1AD06C8C-7495-47B5-8454-9714230DA258, OS:15.5, name:iPhone 12 Pro Max }
+{ platform:iOS Simulator, id:D1A617CE-5A57-4F25-93E1-C2B9B1FC6409, OS:16.0, name:iPhone 12 Pro Max }
+{ platform:iOS Simulator, id:9D6EEDFC-A7D0-4AC6-A9EA-9434CAB1DB70, OS:15.5, name:iPhone 12 mini }
+{ platform:iOS Simulator, id:C03F34F2-422B-40C2-A5DC-3481F4FA5493, OS:16.0, name:iPhone 12 mini }
+{ platform:iOS Simulator, id:4CF39742-EB3D-4224-870E-8AD082B6BAC2, OS:15.5, name:iPhone 13 }
+{ platform:iOS Simulator, id:1E4C27CC-62B2-40EE-8D66-A6BB3F28DCF4, OS:16.0, name:iPhone 13 }
+{ platform:iOS Simulator, id:49F03216-24A3-47EA-8144-B0556C447457, OS:15.5, name:iPhone 13 Pro }
+{ platform:iOS Simulator, id:7920F7BF-B831-4D66-A315-37E2F76E076E, OS:16.0, name:iPhone 13 Pro }
+{ platform:iOS Simulator, id:FFFB3CBC-24A3-4772-99CE-2107EC3B91CF, OS:15.5, name:iPhone 13 Pro Max }
+{ platform:iOS Simulator, id:4FEE3768-28BA-4DC4-B03B-0117A0510467, OS:16.0, name:iPhone 13 Pro Max }
+{ platform:iOS Simulator, id:15609DF4-6D8C-4B77-97A7-017AEDBB82EC, OS:15.5, name:iPhone 13 mini }
+{ platform:iOS Simulator, id:2D3DC8EF-DC4E-4CBC-B003-25125ECF55ED, OS:16.0, name:iPhone 13 mini }
+{ platform:iOS Simulator, id:E4C6E24E-B320-4018-9164-57B2641C0B0F, OS:15.5, name:iPhone SE (3rd generation) }
+{ platform:iOS Simulator, id:8CBFF3A2-9FA1-4E9E-A2EA-91F9DC6EDE1D, OS:16.0, name:iPhone SE (3rd generation) }
+{ platform:iOS Simulator, id:3279AD2D-9358-4142-A45D-C47E81538069, OS:15.5, name:iPod touch (7th generation) }
+2022-09-08 10:46:39.173 xcodebuild[38169:21321197] Requested but did not find extension point with identifier Xcode.InterfaceBuilderBuildSupport.PlatformDefinition
+DEBUG [2022-09-08 10:46:39.69]: Fetching available simulator devices
+
++------------------------------------------------+---------------------------------------------------------------------------------------+
+|                                                        [0;32;49mSummary for scan 2.200.0[0m                                                        |
++------------------------------------------------+---------------------------------------------------------------------------------------+
+| workspace                                      | /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/Bikemap.xcworkspace |
+| fail_build                                     | true                                                                                  |
+| scheme                                         | Bikemap                                                                               |
+| output_types                                   | junit                                                                                 |
+| devices                                        | ["iPhone 8"]                                                                          |
+| skip_detect_devices                            | false                                                                                 |
+| ensure_devices_found                           | false                                                                                 |
+| force_quit_simulator                           | false                                                                                 |
+| reset_simulator                                | false                                                                                 |
+| disable_slide_to_type                          | true                                                                                  |
+| prelaunch_simulator                            | true                                                                                  |
+| reinstall_app                                  | false                                                                                 |
+| app_identifier                                 | com.toursprung.bikemap                                                                |
+| clean                                          | false                                                                                 |
+| open_report                                    | false                                                                                 |
+| output_directory                               | ./fastlane/test_output                                                                |
+| buildlog_path                                  | ~/Library/Logs/scan                                                                   |
+| derived_data_path                              | build/DerivedData                                                                     |
+| should_zip_build_products                      | false                                                                                 |
+| output_xctestrun                               | false                                                                                 |
+| use_clang_report_name                          | false                                                                                 |
+| disable_concurrent_testing                     | false                                                                                 |
+| build_for_testing                              | true                                                                                  |
+| xcargs                                         | -UseNewBuildSystem=YES                                                                |
+| slack_use_webhook_configured_username_and_icon | false                                                                                 |
+| slack_username                                 | fastlane                                                                              |
+| slack_icon_url                                 | https://fastlane.tools/assets/img/fastlane_icon.png                                   |
+| skip_slack                                     | false                                                                                 |
+| slack_only_on_failure                          | false                                                                                 |
+| xcodebuild_command                             | env NSUnbufferedIO=YES xcodebuild                                                     |
+| skip_package_dependencies_resolution           | false                                                                                 |
+| disable_package_automatic_updates              | false                                                                                 |
+| use_system_scm                                 | false                                                                                 |
+| number_of_retries                              | 0                                                                                     |
+| include_simulator_logs                         | false                                                                                 |
+| skip_build                                     | false                                                                                 |
+| xcode_path                                     | /Applications/Xcode-beta.app                                                          |
++------------------------------------------------+---------------------------------------------------------------------------------------+
+
+DEBUG [2022-09-08 10:46:40.03]: Before building, removing pre-existing xctestrun files: []
+DEBUG [2022-09-08 10:46:40.03]: Fetching available simulator devices
+INFO [2022-09-08 10:46:40.33]: Disabling 'Slide to Type' iPhone 8
+INFO [2022-09-08 10:46:40.33]: [0;36;49m$ /usr/libexec/PlistBuddy -c "Add :KeyboardContinuousPathEnabled bool false" /Users/bikemap/Library/Developer/CoreSimulator/Devices/D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E/data/Library/Preferences/com.apple.keyboard.ContinuousPath.plist >/dev/null 2>&1[0m
+INFO [2022-09-08 10:46:40.35]: [0;36;49m$ set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/Bikemap.xcworkspace -scheme Bikemap -derivedDataPath build/DerivedData -destination 'platform=iOS Simulator,id=D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E' -UseNewBuildSystem=YES build-for-testing | tee '/Users/bikemap/Library/Logs/scan/Bikemap-Bikemap.log' | xcpretty  --report junit --output '/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/report.junit' --report junit --output '/var/folders/k9/2frl09_n32vfltrncztxx4_m0000gn/T/junit_report20220908-35977-1mowwre' [0m
+INFO [2022-09-08 10:46:40.35]: ▸ [0;35;49mLoading...[0m
+INFO [2022-09-08 10:47:04.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m _NumericsShims.c[0m
+INFO [2022-09-08 10:47:04.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MBProgressHUD.m[0m
+INFO [2022-09-08 10:47:10.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GTMSessionUploadFetcher.m[0m
+INFO [2022-09-08 10:47:10.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GTMSessionFetcherService.m[0m
+INFO [2022-09-08 10:47:10.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GTMSessionFetcherLogging.m[0m
+INFO [2022-09-08 10:47:10.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GTMSessionFetcher.m[0m
+INFO [2022-09-08 10:47:10.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m writer.c[0m
+INFO [2022-09-08 10:47:10.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m scanner.c[0m
+INFO [2022-09-08 10:47:10.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m reader.c[0m
+INFO [2022-09-08 10:47:10.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Copy XCFrameworks'[0m
+INFO [2022-09-08 10:47:10.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m _NumericsShims.o[0m
+INFO [2022-09-08 10:47:10.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m pb_encode.h[0m
+INFO [2022-09-08 10:47:10.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m pb_decode.h[0m
+INFO [2022-09-08 10:47:10.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m pb_common.h[0m
+INFO [2022-09-08 10:47:10.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m pb.h[0m
+INFO [2022-09-08 10:47:10.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m nanopb-umbrella.h[0m
+INFO [2022-09-08 10:47:10.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m geos_c.h[0m
+INFO [2022-09-08 10:47:10.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m geos-umbrella.h[0m
+INFO [2022-09-08 10:47:10.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m export.h[0m
+INFO [2022-09-08 10:47:10.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Turf.h[0m
+INFO [2022-09-08 10:47:10.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Turf-umbrella.h[0m
+INFO [2022-09-08 10:47:10.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Solar-umbrella.h[0m
+INFO [2022-09-08 10:47:10.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m RangeSeekSlider-umbrella.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m PryntTrimmerView-umbrella.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromisePrivate.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m PromisesObjC-umbrella.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromises.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromiseError.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Wrap.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Validate.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Timeout.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Then.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Testing.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Retry.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Reduce.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Recover.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Race.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Do.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Delay.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Catch.h[0m
+INFO [2022-09-08 10:47:10.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Await.h[0m
+INFO [2022-09-08 10:47:10.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Async.h[0m
+INFO [2022-09-08 10:47:10.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Any.h[0m
+INFO [2022-09-08 10:47:10.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+Always.h[0m
+INFO [2022-09-08 10:47:10.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FBLPromise+All.h[0m
+INFO [2022-09-08 10:47:10.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Polyline.h[0m
+INFO [2022-09-08 10:47:10.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Polyline-framework-umbrella.h[0m
+INFO [2022-09-08 10:47:10.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Copy XCFrameworks'[0m
+INFO [2022-09-08 10:47:10.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m MapboxSpeech.h[0m
+INFO [2022-09-08 10:47:10.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m MapboxSpeech-umbrella.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m ImageViewer-umbrella.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m NSArray+FEMPropertyRepresentation.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMObjectRef.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMMergeableCollection.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMExcludableCollection.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FastEasyMapping.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FastEasyMapping-umbrella.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMTypes.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMTypeIntrospection.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMSerializer.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMRepresentationUtility.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMRelationshipAssignmentContext.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMRelationshipAssignmentContext+Internal.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMRelationship.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMProperty.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMObjectStore.h[0m
+INFO [2022-09-08 10:47:10.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMObjectCache.h[0m
+INFO [2022-09-08 10:47:10.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMMapping.h[0m
+INFO [2022-09-08 10:47:10.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMManagedObjectStore.h[0m
+INFO [2022-09-08 10:47:10.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMDeserializer.h[0m
+INFO [2022-09-08 10:47:10.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMAttribute.h[0m
+INFO [2022-09-08 10:47:10.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FEMAssignmentPolicy.h[0m
+INFO [2022-09-08 10:47:10.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m nanopb-Info.plist[0m
+INFO [2022-09-08 10:47:10.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m pb_encode.c[0m
+INFO [2022-09-08 10:47:10.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Copy XCFrameworks'[0m
+INFO [2022-09-08 10:47:10.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m pb_decode.c[0m
+INFO [2022-09-08 10:47:10.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m pb_common.c[0m
+INFO [2022-09-08 10:47:10.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m nanopb_vers.c[0m
+INFO [2022-09-08 10:47:10.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m nanopb-dummy.m[0m
+INFO [2022-09-08 10:47:10.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m geos-Info.plist[0m
+INFO [2022-09-08 10:47:10.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m math.cpp[0m
+INFO [2022-09-08 10:47:10.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m geos_vers.c[0m
+INFO [2022-09-08 10:47:10.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m geos_ts_c.cpp[0m
+INFO [2022-09-08 10:47:11.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m geos_c.cpp[0m
+INFO [2022-09-08 10:47:11.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m geos-dummy.m[0m
+INFO [2022-09-08 10:47:14.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m d2s.c[0m
+INFO [2022-09-08 10:47:14.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Writer.cpp[0m
+INFO [2022-09-08 10:47:14.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WKTWriter.cpp[0m
+INFO [2022-09-08 10:47:14.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m MBProgressHUD.o[0m
+INFO [2022-09-08 10:47:14.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WKTReader.cpp[0m
+INFO [2022-09-08 10:47:14.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WKBWriter.cpp[0m
+INFO [2022-09-08 10:47:14.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WKBReader.cpp[0m
+INFO [2022-09-08 10:47:14.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m GTMSessionFetcherCore.o[0m
+INFO [2022-09-08 10:47:14.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VoronoiDiagramBuilder.cpp[0m
+INFO [2022-09-08 10:47:14.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m nanopb[0m
+INFO [2022-09-08 10:47:14.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VertexSequencePackedRtree.cpp[0m
+INFO [2022-09-08 10:47:14.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Vertex.cpp[0m
+INFO [2022-09-08 10:47:14.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ValidatingNoder.cpp[0m
+INFO [2022-09-08 10:47:14.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Unload.cpp[0m
+INFO [2022-09-08 10:47:14.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnionStrategy.cpp[0m
+INFO [2022-09-08 10:47:14.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnaryUnionOp.cpp[0m
+INFO [2022-09-08 10:47:14.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnaryUnionNG.cpp[0m
+INFO [2022-09-08 10:47:14.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TriangulationBuilder.cpp[0m
+INFO [2022-09-08 10:47:14.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TrianglePredicate.cpp[0m
+INFO [2022-09-08 10:47:14.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Triangle.cpp[0m
+INFO [2022-09-08 10:47:14.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TriList.cpp[0m
+INFO [2022-09-08 10:47:14.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TriEdge.cpp[0m
+INFO [2022-09-08 10:47:14.42]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m nanopb.framework (in target 'nanopb' from project 'Pods')[0m
+INFO [2022-09-08 10:47:14.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TriDelaunayImprover.cpp[0m
+INFO [2022-09-08 10:47:14.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Tri.cpp[0m
+INFO [2022-09-08 10:47:14.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TopologyValidationError.cpp[0m
+INFO [2022-09-08 10:47:14.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TopologyPreservingSimplifier.cpp[0m
+INFO [2022-09-08 10:47:15.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TopologyLocation.cpp[0m
+INFO [2022-09-08 10:47:15.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TaggedLinesSimplifier.cpp[0m
+INFO [2022-09-08 10:47:15.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TaggedLineStringSimplifier.cpp[0m
+INFO [2022-09-08 10:47:15.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TaggedLineString.cpp[0m
+INFO [2022-09-08 10:47:15.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TaggedLineSegment.cpp[0m
+INFO [2022-09-08 10:47:15.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SweepLineSegment.cpp[0m
+INFO [2022-09-08 10:47:15.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SweepLineInterval.cpp[0m
+INFO [2022-09-08 10:47:15.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SweepLineIndex.cpp[0m
+INFO [2022-09-08 10:47:15.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SweepLineEvent.cpp[0m
+INFO [2022-09-08 10:47:15.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SweepLineEvent.cpp[0m
+INFO [2022-09-08 10:47:15.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SubgraphDepthLocater.cpp[0m
+INFO [2022-09-08 10:47:16.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Subgraph.cpp[0m
+INFO [2022-09-08 10:47:16.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StringTokenizer.cpp[0m
+INFO [2022-09-08 10:47:16.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SortedPackedIntervalRTree.cpp[0m
+INFO [2022-09-08 10:47:16.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SnappingPointIndex.cpp[0m
+INFO [2022-09-08 10:47:16.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SnappingNoder.cpp[0m
+INFO [2022-09-08 10:47:16.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SnappingIntersectionAdder.cpp[0m
+INFO [2022-09-08 10:47:16.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SnapRoundingNoder.cpp[0m
+INFO [2022-09-08 10:47:17.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SnapRoundingIntersectionAdder.cpp[0m
+INFO [2022-09-08 10:47:17.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SnapOverlayOp.cpp[0m
+INFO [2022-09-08 10:47:17.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SineStarFactory.cpp[0m
+INFO [2022-09-08 10:47:17.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimpleSweepLineIntersector.cpp[0m
+INFO [2022-09-08 10:47:17.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimpleSTRtree.cpp[0m
+INFO [2022-09-08 10:47:17.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimpleSTRnode.cpp[0m
+INFO [2022-09-08 10:47:17.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimpleSTRdistance.cpp[0m
+INFO [2022-09-08 10:47:18.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimplePointInRing.cpp[0m
+INFO [2022-09-08 10:47:18.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimplePointInAreaLocator.cpp[0m
+INFO [2022-09-08 10:47:18.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimpleNoder.cpp[0m
+INFO [2022-09-08 10:47:18.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimpleMCSweepLineIntersector.cpp[0m
+INFO [2022-09-08 10:47:18.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimpleGeometryPrecisionReducer.cpp[0m
+INFO [2022-09-08 10:47:18.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimpleEdgeSetIntersector.cpp[0m
+INFO [2022-09-08 10:47:18.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ShortCircuitedGeometryVisitor.cpp[0m
+INFO [2022-09-08 10:47:18.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SharedPathsOp.cpp[0m
+INFO [2022-09-08 10:47:19.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SegmentStringUtil.cpp[0m
+INFO [2022-09-08 10:47:19.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SegmentString.cpp[0m
+INFO [2022-09-08 10:47:19.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SegmentNodeList.cpp[0m
+INFO [2022-09-08 10:47:19.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SegmentNode.cpp[0m
+INFO [2022-09-08 10:47:19.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SegmentIntersector.cpp[0m
+INFO [2022-09-08 10:47:19.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SegmentIntersectionTester.cpp[0m
+INFO [2022-09-08 10:47:19.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SegmentIntersectionDetector.cpp[0m
+INFO [2022-09-08 10:47:19.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ScaledNoder.cpp[0m
+INFO [2022-09-08 10:47:20.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m STRtree.cpp[0m
+INFO [2022-09-08 10:47:20.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SIRtree.cpp[0m
+INFO [2022-09-08 10:47:20.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Root.cpp[0m
+INFO [2022-09-08 10:47:20.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Root.cpp[0m
+INFO [2022-09-08 10:47:20.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RobustDeterminant.cpp[0m
+INFO [2022-09-08 10:47:20.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RobustClipEnvelopeComputer.cpp[0m
+INFO [2022-09-08 10:47:20.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RingClipper.cpp[0m
+INFO [2022-09-08 10:47:20.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RightmostEdgeFinder.cpp[0m
+INFO [2022-09-08 10:47:21.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RepeatedPointTester.cpp[0m
+INFO [2022-09-08 10:47:21.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RepeatedPointRemover.cpp[0m
+INFO [2022-09-08 10:47:21.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RelateOp.cpp[0m
+INFO [2022-09-08 10:47:21.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RelateNodeGraph.cpp[0m
+INFO [2022-09-08 10:47:21.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RelateNodeFactory.cpp[0m
+INFO [2022-09-08 10:47:21.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RelateNode.cpp[0m
+INFO [2022-09-08 10:47:21.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RelateComputer.cpp[0m
+INFO [2022-09-08 10:47:22.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RectangleIntersects.cpp[0m
+INFO [2022-09-08 10:47:22.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RectangleIntersectionBuilder.cpp[0m
+INFO [2022-09-08 10:47:22.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RectangleIntersection.cpp[0m
+INFO [2022-09-08 10:47:22.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RectangleContains.cpp[0m
+INFO [2022-09-08 10:47:22.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Rectangle.cpp[0m
+INFO [2022-09-08 10:47:22.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RayCrossingCounterDD.cpp[0m
+INFO [2022-09-08 10:47:22.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RayCrossingCounter.cpp[0m
+INFO [2022-09-08 10:47:22.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Quadtree.cpp[0m
+INFO [2022-09-08 10:47:23.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Quadrant.cpp[0m
+INFO [2022-09-08 10:47:23.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m QuadEdgeSubdivision.cpp[0m
+INFO [2022-09-08 10:47:24.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m QuadEdge.cpp[0m
+INFO [2022-09-08 10:47:24.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Profiler.cpp[0m
+INFO [2022-09-08 10:47:24.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedPolygonPredicate.cpp[0m
+INFO [2022-09-08 10:47:24.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedPolygonIntersects.cpp[0m
+INFO [2022-09-08 10:47:24.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedPolygonDistance.cpp[0m
+INFO [2022-09-08 10:47:24.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedPolygonCovers.cpp[0m
+INFO [2022-09-08 10:47:24.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedPolygonContainsProperly.cpp[0m
+INFO [2022-09-08 10:47:24.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedPolygonContains.cpp[0m
+INFO [2022-09-08 10:47:24.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedPolygon.cpp[0m
+INFO [2022-09-08 10:47:25.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedPoint.cpp[0m
+INFO [2022-09-08 10:47:25.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedLineStringNearestPoints.cpp[0m
+INFO [2022-09-08 10:47:25.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedLineStringIntersects.cpp[0m
+INFO [2022-09-08 10:47:25.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedLineStringDistance.cpp[0m
+INFO [2022-09-08 10:47:25.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedLineString.cpp[0m
+INFO [2022-09-08 10:47:25.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedGeometryFactory.cpp[0m
+INFO [2022-09-08 10:47:25.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PreparedGeometry.cpp[0m
+INFO [2022-09-08 10:47:25.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PrecisionUtil.cpp[0m
+INFO [2022-09-08 10:47:25.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PrecisionReducerTransformer.cpp[0m
+INFO [2022-09-08 10:47:26.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PrecisionReducerCoordinateOperation.cpp[0m
+INFO [2022-09-08 10:47:26.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PrecisionReducer.cpp[0m
+INFO [2022-09-08 10:47:26.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PrecisionModel.cpp[0m
+INFO [2022-09-08 10:47:26.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Position.cpp[0m
+INFO [2022-09-08 10:47:26.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polygonizer.cpp[0m
+INFO [2022-09-08 10:47:27.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonizeGraph.cpp[0m
+INFO [2022-09-08 10:47:27.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonizeEdge.cpp[0m
+INFO [2022-09-08 10:47:27.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonizeDirectedEdge.cpp[0m
+INFO [2022-09-08 10:47:27.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonTriangulator.cpp[0m
+INFO [2022-09-08 10:47:27.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonTopologyAnalyzer.cpp[0m
+INFO [2022-09-08 10:47:28.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonRingTouch.cpp[0m
+INFO [2022-09-08 10:47:28.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonRingSelfNode.cpp[0m
+INFO [2022-09-08 10:47:28.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonRing.cpp[0m
+INFO [2022-09-08 10:47:28.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonNode.cpp[0m
+INFO [2022-09-08 10:47:28.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonIntersectionAnalyzer.cpp[0m
+INFO [2022-09-08 10:47:28.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonHoleJoiner.cpp[0m
+INFO [2022-09-08 10:47:29.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonExtracter.cpp[0m
+INFO [2022-09-08 10:47:29.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonEarClipper.cpp[0m
+INFO [2022-09-08 10:47:29.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonBuilder.cpp[0m
+INFO [2022-09-08 10:47:29.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonBuilder.cpp[0m
+INFO [2022-09-08 10:47:30.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polygon.cpp[0m
+INFO [2022-09-08 10:47:30.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PointwisePrecisionReducerTransformer.cpp[0m
+INFO [2022-09-08 10:47:30.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PointOnGeometryLocator.cpp[0m
+INFO [2022-09-08 10:47:30.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PointLocator.cpp[0m
+INFO [2022-09-08 10:47:30.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PointLocation.cpp[0m
+INFO [2022-09-08 10:47:30.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PointGeometryUnion.cpp[0m
+INFO [2022-09-08 10:47:30.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PointExtracter.cpp[0m
+INFO [2022-09-08 10:47:30.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PointBuilder.cpp[0m
+INFO [2022-09-08 10:47:30.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Point.cpp[0m
+INFO [2022-09-08 10:47:30.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PlanarGraph.cpp[0m
+INFO [2022-09-08 10:47:31.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PlanarGraph.cpp[0m
+INFO [2022-09-08 10:47:31.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ParseException.cpp[0m
+INFO [2022-09-08 10:47:31.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayUtil.cpp[0m
+INFO [2022-09-08 10:47:31.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayResultValidator.cpp[0m
+INFO [2022-09-08 10:47:31.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayPoints.cpp[0m
+INFO [2022-09-08 10:47:32.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayOp.cpp[0m
+INFO [2022-09-08 10:47:32.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayNodeFactory.cpp[0m
+INFO [2022-09-08 10:47:32.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayNGRobust.cpp[0m
+INFO [2022-09-08 10:47:32.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayNG.cpp[0m
+INFO [2022-09-08 10:47:33.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayMixedPoints.cpp[0m
+INFO [2022-09-08 10:47:33.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayLabeller.cpp[0m
+INFO [2022-09-08 10:47:33.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayLabel.cpp[0m
+INFO [2022-09-08 10:47:33.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayGraph.cpp[0m
+INFO [2022-09-08 10:47:33.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayEdgeRing.cpp[0m
+INFO [2022-09-08 10:47:33.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlayEdge.cpp[0m
+INFO [2022-09-08 10:47:33.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OverlapUnion.cpp[0m
+INFO [2022-09-08 10:47:34.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OrientedCoordinateArray.cpp[0m
+INFO [2022-09-08 10:47:34.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Orientation.cpp[0m
+INFO [2022-09-08 10:47:34.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OffsetSegmentGenerator.cpp[0m
+INFO [2022-09-08 10:47:34.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OffsetPointGenerator.cpp[0m
+INFO [2022-09-08 10:47:34.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OffsetCurveSetBuilder.cpp[0m
+INFO [2022-09-08 10:47:34.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OffsetCurveBuilder.cpp[0m
+INFO [2022-09-08 10:47:34.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Octant.cpp[0m
+INFO [2022-09-08 10:47:34.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NotRepresentableException.cpp[0m
+INFO [2022-09-08 10:47:34.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NodingValidator.cpp[0m
+INFO [2022-09-08 10:47:34.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NodingIntersectionFinder.cpp[0m
+INFO [2022-09-08 10:47:35.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NodedSegmentString.cpp[0m
+INFO [2022-09-08 10:47:35.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NodeMap.cpp[0m
+INFO [2022-09-08 10:47:35.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NodeMap.cpp[0m
+INFO [2022-09-08 10:47:35.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NodeFactory.cpp[0m
+INFO [2022-09-08 10:47:35.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NodeBase.cpp[0m
+INFO [2022-09-08 10:47:35.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NodeBase.cpp[0m
+INFO [2022-09-08 10:47:36.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Node.cpp[0m
+INFO [2022-09-08 10:47:36.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Node.cpp[0m
+INFO [2022-09-08 10:47:36.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Node.cpp[0m
+INFO [2022-09-08 10:47:36.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Node.cpp[0m
+INFO [2022-09-08 10:47:36.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NoOpGeometryOperation.cpp[0m
+INFO [2022-09-08 10:47:36.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiPolygon.cpp[0m
+INFO [2022-09-08 10:47:36.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiPoint.cpp[0m
+INFO [2022-09-08 10:47:36.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiLineString.cpp[0m
+INFO [2022-09-08 10:47:37.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MortonCode.cpp[0m
+INFO [2022-09-08 10:47:37.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MonotoneChainSelectAction.cpp[0m
+INFO [2022-09-08 10:47:37.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MonotoneChainOverlapAction.cpp[0m
+INFO [2022-09-08 10:47:37.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MonotoneChainIndexer.cpp[0m
+INFO [2022-09-08 10:47:37.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MonotoneChainEdge.cpp[0m
+INFO [2022-09-08 10:47:37.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MonotoneChainBuilder.cpp[0m
+INFO [2022-09-08 10:47:37.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MonotoneChain.cpp[0m
+INFO [2022-09-08 10:47:37.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MinimumDiameter.cpp[0m
+INFO [2022-09-08 10:47:38.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MinimumClearance.cpp[0m
+INFO [2022-09-08 10:47:38.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MinimumBoundingCircle.cpp[0m
+INFO [2022-09-08 10:47:38.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MinimalEdgeRing.cpp[0m
+INFO [2022-09-08 10:47:38.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MaximumInscribedCircle.cpp[0m
+INFO [2022-09-08 10:47:38.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MaximalEdgeRing.cpp[0m
+INFO [2022-09-08 10:47:38.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MaximalEdgeRing.cpp[0m
+INFO [2022-09-08 10:47:39.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MarkHalfEdge.cpp[0m
+INFO [2022-09-08 10:47:39.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MakeValid.cpp[0m
+INFO [2022-09-08 10:47:39.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MCIndexSnapRounder.cpp[0m
+INFO [2022-09-08 10:47:39.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MCIndexSegmentSetMutualIntersector.cpp[0m
+INFO [2022-09-08 10:47:39.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MCIndexPointSnapper.cpp[0m
+INFO [2022-09-08 10:47:39.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MCIndexNoder.cpp[0m
+INFO [2022-09-08 10:47:39.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LocationIndexOfPoint.cpp[0m
+INFO [2022-09-08 10:47:39.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LocationIndexOfLine.cpp[0m
+INFO [2022-09-08 10:47:39.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Location.cpp[0m
+INFO [2022-09-08 10:47:39.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LocateFailureException.cpp[0m
+INFO [2022-09-08 10:47:40.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LinearRing.cpp[0m
+INFO [2022-09-08 10:47:40.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LinearLocation.cpp[0m
+INFO [2022-09-08 10:47:40.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LinearIterator.cpp[0m
+INFO [2022-09-08 10:47:40.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LinearGeometryBuilder.cpp[0m
+INFO [2022-09-08 10:47:41.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LinearComponentExtracter.cpp[0m
+INFO [2022-09-08 10:47:41.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineStringSnapper.cpp[0m
+INFO [2022-09-08 10:47:41.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineString.cpp[0m
+INFO [2022-09-08 10:47:41.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineSequencer.cpp[0m
+INFO [2022-09-08 10:47:42.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineSegmentIndex.cpp[0m
+INFO [2022-09-08 10:47:42.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineSegment.cpp[0m
+INFO [2022-09-08 10:47:42.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineMerger.cpp[0m
+INFO [2022-09-08 10:47:42.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineMergeGraph.cpp[0m
+INFO [2022-09-08 10:47:42.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineMergeEdge.cpp[0m
+INFO [2022-09-08 10:47:42.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineMergeDirectedEdge.cpp[0m
+INFO [2022-09-08 10:47:42.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineLimiter.cpp[0m
+INFO [2022-09-08 10:47:42.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineIntersector.cpp[0m
+INFO [2022-09-08 10:47:42.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineBuilder.cpp[0m
+INFO [2022-09-08 10:47:43.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineBuilder.cpp[0m
+INFO [2022-09-08 10:47:43.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LengthLocationMap.cpp[0m
+INFO [2022-09-08 10:47:43.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LengthIndexedLine.cpp[0m
+INFO [2022-09-08 10:47:43.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LengthIndexOfPoint.cpp[0m
+INFO [2022-09-08 10:47:43.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Length.cpp[0m
+INFO [2022-09-08 10:47:43.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LastFoundQuadEdgeLocator.cpp[0m
+INFO [2022-09-08 10:47:43.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LargestEmptyCircle.cpp[0m
+INFO [2022-09-08 10:47:44.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Label.cpp[0m
+INFO [2022-09-08 10:47:44.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Key.cpp[0m
+INFO [2022-09-08 10:47:44.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Key.cpp[0m
+INFO [2022-09-08 10:47:44.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m KdTree.cpp[0m
+INFO [2022-09-08 10:47:44.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m KdNode.cpp[0m
+INFO [2022-09-08 10:47:44.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IteratedNoder.cpp[0m
+INFO [2022-09-08 10:47:44.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IsValidOp.cpp[0m
+INFO [2022-09-08 10:47:45.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IsSimpleOp.cpp[0m
+INFO [2022-09-08 10:47:45.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IntervalSize.cpp[0m
+INFO [2022-09-08 10:47:45.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IntervalRTreeLeafNode.cpp[0m
+INFO [2022-09-08 10:47:45.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IntervalRTreeBranchNode.cpp[0m
+INFO [2022-09-08 10:47:45.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Interval.cpp[0m
+INFO [2022-09-08 10:47:45.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Interval.cpp[0m
+INFO [2022-09-08 10:47:45.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IntersectionPointBuilder.cpp[0m
+INFO [2022-09-08 10:47:46.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IntersectionMatrix.cpp[0m
+INFO [2022-09-08 10:47:46.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IntersectionFinderAdder.cpp[0m
+INFO [2022-09-08 10:47:46.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IntersectionAdder.cpp[0m
+INFO [2022-09-08 10:47:46.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Intersection.cpp[0m
+INFO [2022-09-08 10:47:46.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Interrupt.cpp[0m
+INFO [2022-09-08 10:47:46.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InteriorPointPoint.cpp[0m
+INFO [2022-09-08 10:47:46.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InteriorPointLine.cpp[0m
+INFO [2022-09-08 10:47:46.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InteriorPointArea.cpp[0m
+INFO [2022-09-08 10:47:46.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InputGeometry.cpp[0m
+INFO [2022-09-08 10:47:46.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IndexedPointOnLineLocator.cpp[0m
+INFO [2022-09-08 10:47:46.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IndexedPointInAreaLocator.cpp[0m
+INFO [2022-09-08 10:47:46.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IndexedNestedPolygonTester.cpp[0m
+INFO [2022-09-08 10:47:47.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IndexedNestedHoleTester.cpp[0m
+INFO [2022-09-08 10:47:47.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IndexedFacetDistance.cpp[0m
+INFO [2022-09-08 10:47:47.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IncrementalDelaunayTriangulator.cpp[0m
+INFO [2022-09-08 10:47:47.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HotPixelIndex.cpp[0m
+INFO [2022-09-08 10:47:47.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HotPixel.cpp[0m
+INFO [2022-09-08 10:47:47.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HoleAssigner.cpp[0m
+INFO [2022-09-08 10:47:48.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HilbertEncoder.cpp[0m
+INFO [2022-09-08 10:47:48.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HilbertCode.cpp[0m
+INFO [2022-09-08 10:47:48.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HeuristicOverlay.cpp[0m
+INFO [2022-09-08 10:47:49.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HalfEdge.cpp[0m
+INFO [2022-09-08 10:47:49.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HCoordinate.cpp[0m
+INFO [2022-09-08 10:47:49.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GraphComponent.cpp[0m
+INFO [2022-09-08 10:47:49.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryTransformer.cpp[0m
+INFO [2022-09-08 10:47:49.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometrySnapper.cpp[0m
+INFO [2022-09-08 10:47:49.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryPrecisionReducer.cpp[0m
+INFO [2022-09-08 10:47:49.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryNoder.cpp[0m
+INFO [2022-09-08 10:47:49.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryLocation.cpp[0m
+INFO [2022-09-08 10:47:49.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryItemDistance.cpp[0m
+INFO [2022-09-08 10:47:49.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryGraphOperation.cpp[0m
+INFO [2022-09-08 10:47:49.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryGraph.cpp[0m
+INFO [2022-09-08 10:47:50.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryFixer.cpp[0m
+INFO [2022-09-08 10:47:51.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryFactory.cpp[0m
+INFO [2022-09-08 10:47:51.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryEditor.cpp[0m
+INFO [2022-09-08 10:47:51.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryComponentFilter.cpp[0m
+INFO [2022-09-08 10:47:51.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryCombiner.cpp[0m
+INFO [2022-09-08 10:47:51.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryCollection.cpp[0m
+INFO [2022-09-08 10:47:51.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Geometry.cpp[0m
+INFO [2022-09-08 10:47:51.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometricShapeFactory.cpp[0m
+INFO [2022-09-08 10:47:51.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSONWriter.cpp[0m
+INFO [2022-09-08 10:47:53.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSONReader.cpp[0m
+INFO [2022-09-08 10:47:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSON.cpp[0m
+INFO [2022-09-08 10:47:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FuzzyPointLocator.cpp[0m
+INFO [2022-09-08 10:47:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FastSegmentSetIntersectionFinder.cpp[0m
+INFO [2022-09-08 10:47:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FastNodingValidator.cpp[0m
+INFO [2022-09-08 10:47:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FacetSequenceTreeBuilder.cpp[0m
+INFO [2022-09-08 10:47:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FacetSequence.cpp[0m
+INFO [2022-09-08 10:47:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ExtractLineByLocation.cpp[0m
+INFO [2022-09-08 10:47:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EnvelopeUtil.cpp[0m
+INFO [2022-09-08 10:47:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Envelope.cpp[0m
+INFO [2022-09-08 10:47:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EnhancedPrecisionOp.cpp[0m
+INFO [2022-09-08 10:47:54.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ElevationModel.cpp[0m
+INFO [2022-09-08 10:47:54.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ElevationMatrixCell.cpp[0m
+INFO [2022-09-08 10:47:54.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ElevationMatrix.cpp[0m
+INFO [2022-09-08 10:47:54.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeString.cpp[0m
+INFO [2022-09-08 10:47:54.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeSourceInfo.cpp[0m
+INFO [2022-09-08 10:47:54.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeSetNoder.cpp[0m
+INFO [2022-09-08 10:47:54.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeRing.cpp[0m
+INFO [2022-09-08 10:47:55.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeRing.cpp[0m
+INFO [2022-09-08 10:47:55.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeNodingValidator.cpp[0m
+INFO [2022-09-08 10:47:55.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeNodingBuilder.cpp[0m
+INFO [2022-09-08 10:47:56.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeMerger.cpp[0m
+INFO [2022-09-08 10:47:56.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeList.cpp[0m
+INFO [2022-09-08 10:47:56.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeKey.cpp[0m
+INFO [2022-09-08 10:47:56.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeIntersectionList.cpp[0m
+INFO [2022-09-08 10:47:56.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeGraphBuilder.cpp[0m
+INFO [2022-09-08 10:47:56.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeGraph.cpp[0m
+INFO [2022-09-08 10:47:56.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeEndStar.cpp[0m
+INFO [2022-09-08 10:47:56.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeEndBundleStar.cpp[0m
+INFO [2022-09-08 10:47:56.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeEndBundle.cpp[0m
+INFO [2022-09-08 10:47:56.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeEndBuilder.cpp[0m
+INFO [2022-09-08 10:47:56.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EdgeEnd.cpp[0m
+INFO [2022-09-08 10:47:56.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Edge.cpp[0m
+INFO [2022-09-08 10:47:57.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Edge.cpp[0m
+INFO [2022-09-08 10:47:57.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Edge.cpp[0m
+INFO [2022-09-08 10:47:57.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DouglasPeuckerSimplifier.cpp[0m
+INFO [2022-09-08 10:47:57.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DouglasPeuckerLineSimplifier.cpp[0m
+INFO [2022-09-08 10:47:57.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DistanceToPoint.cpp[0m
+INFO [2022-09-08 10:47:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DistanceOp.cpp[0m
+INFO [2022-09-08 10:47:58.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Distance.cpp[0m
+INFO [2022-09-08 10:47:58.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DiscreteHausdorffDistance.cpp[0m
+INFO [2022-09-08 10:47:58.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DiscreteFrechetDistance.cpp[0m
+INFO [2022-09-08 10:47:58.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DirectedEdgeStar.cpp[0m
+INFO [2022-09-08 10:47:58.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DirectedEdgeStar.cpp[0m
+INFO [2022-09-08 10:47:58.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DirectedEdge.cpp[0m
+INFO [2022-09-08 10:47:59.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DirectedEdge.cpp[0m
+INFO [2022-09-08 10:47:59.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Dimension.cpp[0m
+INFO [2022-09-08 10:47:59.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Depth.cpp[0m
+INFO [2022-09-08 10:47:59.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Densifier.cpp[0m
+INFO [2022-09-08 10:47:59.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DelaunayTriangulationBuilder.cpp[0m
+INFO [2022-09-08 10:47:59.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DefaultCoordinateSequenceFactory.cpp[0m
+INFO [2022-09-08 10:47:59.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DD.cpp[0m
+INFO [2022-09-08 10:47:59.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoverageUnion.cpp[0m
+INFO [2022-09-08 10:48:00.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoordinateSequence.cpp[0m
+INFO [2022-09-08 10:48:00.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoordinateOperation.cpp[0m
+INFO [2022-09-08 10:48:00.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoordinateArraySequenceFactory.cpp[0m
+INFO [2022-09-08 10:48:00.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoordinateArraySequence.cpp[0m
+INFO [2022-09-08 10:48:00.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Coordinate.cpp[0m
+INFO [2022-09-08 10:48:00.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ConvexHull.cpp[0m
+INFO [2022-09-08 10:48:01.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ConstrainedDelaunayTriangulator.cpp[0m
+INFO [2022-09-08 10:48:01.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ConsistentAreaTester.cpp[0m
+INFO [2022-09-08 10:48:01.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ConnectedSubgraphFinder.cpp[0m
+INFO [2022-09-08 10:48:01.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ConnectedInteriorTester.cpp[0m
+INFO [2022-09-08 10:48:01.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ConnectedElementPointFilter.cpp[0m
+INFO [2022-09-08 10:48:01.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ConnectedElementLocationFilter.cpp[0m
+INFO [2022-09-08 10:48:01.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ComponentCoordinateExtracter.cpp[0m
+INFO [2022-09-08 10:48:01.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CommonBitsRemover.cpp[0m
+INFO [2022-09-08 10:48:01.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CommonBitsOp.cpp[0m
+INFO [2022-09-08 10:48:02.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CommonBits.cpp[0m
+INFO [2022-09-08 10:48:02.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Centroid.cpp[0m
+INFO [2022-09-08 10:48:02.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CascadedPolygonUnion.cpp[0m
+INFO [2022-09-08 10:48:03.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CLocalizer.cpp[0m
+INFO [2022-09-08 10:48:03.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CGAlgorithmsDD.cpp[0m
+INFO [2022-09-08 10:48:03.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ByteOrderValues.cpp[0m
+INFO [2022-09-08 10:48:03.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ByteOrderDataInStream.cpp[0m
+INFO [2022-09-08 10:48:03.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BuildArea.cpp[0m
+INFO [2022-09-08 10:48:03.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BufferSubgraph.cpp[0m
+INFO [2022-09-08 10:48:03.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BufferParameters.cpp[0m
+INFO [2022-09-08 10:48:03.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BufferOp.cpp[0m
+INFO [2022-09-08 10:48:03.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BufferInputLineSimplifier.cpp[0m
+INFO [2022-09-08 10:48:03.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BufferBuilder.cpp[0m
+INFO [2022-09-08 10:48:04.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BoundaryNodeRule.cpp[0m
+INFO [2022-09-08 10:48:04.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BoundablePair.cpp[0m
+INFO [2022-09-08 10:48:04.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Bintree.cpp[0m
+INFO [2022-09-08 10:48:04.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BasicSegmentString.cpp[0m
+INFO [2022-09-08 10:48:04.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BasicPreparedGeometry.cpp[0m
+INFO [2022-09-08 10:48:04.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Assert.cpp[0m
+INFO [2022-09-08 10:48:04.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Area.cpp[0m
+INFO [2022-09-08 10:48:04.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Angle.cpp[0m
+INFO [2022-09-08 10:48:04.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AbstractSTRtree.cpp[0m
+INFO [2022-09-08 10:48:04.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AbstractPreparedPolygonContains.cpp[0m
+INFO [2022-09-08 10:48:05.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/zh-Hant.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/zh-Hans.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/vi.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/tr.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/th.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/sv.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/ru.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/ro.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/pt-PT.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/pt-BR.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/pl.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/nl.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/nb.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/ko.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/km.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/km-KH.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/ja.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/it.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/id.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/fr.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/fa.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/es.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/en.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/de.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/da.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/cs.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/bg.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/YPImagePicker_YPImagePicker.bundle/ar.lproj/YPImagePickerLocalizable.strings[0m
+INFO [2022-09-08 10:48:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLibraryView.xib[0m
+INFO [2022-09-08 10:48:07.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Turf-Info.plist[0m
+INFO [2022-09-08 10:48:07.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Solar-Info.plist[0m
+INFO [2022-09-08 10:48:07.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m RangeSeekSlider-Info.plist[0m
+INFO [2022-09-08 10:48:07.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m PryntTrimmerView-Info.plist[0m
+INFO [2022-09-08 10:48:07.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m PromisesObjC-Info.plist[0m
+INFO [2022-09-08 10:48:07.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PromisesObjC-dummy.m[0m
+INFO [2022-09-08 10:48:08.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m geos[0m
+INFO [2022-09-08 10:48:11.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Archive+ZIP64.swift[0m
+INFO [2022-09-08 10:48:11.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Archive.swift[0m
+INFO [2022-09-08 10:48:11.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Archive+Writing.swift[0m
+INFO [2022-09-08 10:48:11.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Archive+WritingDeprecated.swift[0m
+INFO [2022-09-08 10:48:11.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Entry+ZIP64.swift[0m
+INFO [2022-09-08 10:48:11.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Entry.swift[0m
+INFO [2022-09-08 10:48:11.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Archive+BackingConfiguration.swift[0m
+INFO [2022-09-08 10:48:11.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Archive+Helpers.swift[0m
+INFO [2022-09-08 10:48:11.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Archive+MemoryFile.swift[0m
+INFO [2022-09-08 10:48:11.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FileManager+ZIP.swift[0m
+INFO [2022-09-08 10:48:11.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m URL+ZIP.swift[0m
+INFO [2022-09-08 10:48:11.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Data+Compression.swift[0m
+INFO [2022-09-08 10:48:11.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Data+CompressionDeprecated.swift[0m
+INFO [2022-09-08 10:48:11.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Data+Serialization.swift[0m
+INFO [2022-09-08 10:48:11.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Entry+Serialization.swift[0m
+INFO [2022-09-08 10:48:11.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Archive+Progress.swift[0m
+INFO [2022-09-08 10:48:11.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Archive+Reading.swift[0m
+INFO [2022-09-08 10:48:11.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Archive+ReadingDeprecated.swift[0m
+INFO [2022-09-08 10:48:11.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Emitter.swift[0m
+INFO [2022-09-08 10:48:11.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Encoder.swift[0m
+INFO [2022-09-08 10:48:11.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YamlError.swift[0m
+INFO [2022-09-08 10:48:11.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Representer.swift[0m
+INFO [2022-09-08 10:48:11.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Resolver.swift[0m
+INFO [2022-09-08 10:48:11.98]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m geos.framework (in target 'geos' from project 'Pods')[0m
+INFO [2022-09-08 10:48:11.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Node.swift[0m
+INFO [2022-09-08 10:48:11.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Parser.swift[0m
+INFO [2022-09-08 10:48:11.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Node.Scalar.swift[0m
+INFO [2022-09-08 10:48:12.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Node.Sequence.swift[0m
+INFO [2022-09-08 10:48:12.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Mark.swift[0m
+INFO [2022-09-08 10:48:12.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Node.Mapping.swift[0m
+INFO [2022-09-08 10:48:12.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m String+Yams.swift[0m
+INFO [2022-09-08 10:48:12.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Tag.swift[0m
+INFO [2022-09-08 10:48:12.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Constructor.swift[0m
+INFO [2022-09-08 10:48:12.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Decoder.swift[0m
+INFO [2022-09-08 10:48:12.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m empty-YPImagePicker_YPImagePicker.plist[0m
+INFO [2022-09-08 10:48:12.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m ZIPFoundation.o[0m
+INFO [2022-09-08 10:48:12.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Turf_vers.c[0m
+INFO [2022-09-08 10:48:12.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Turf-dummy.m[0m
+INFO [2022-09-08 10:48:14.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiPoint.swift[0m
+INFO [2022-09-08 10:48:14.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiPolygon.swift[0m
+INFO [2022-09-08 10:48:14.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Feature.swift[0m
+INFO [2022-09-08 10:48:14.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FeatureCollection.swift[0m
+INFO [2022-09-08 10:48:14.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FeatureIdentifier.swift[0m
+INFO [2022-09-08 10:48:14.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineString.swift[0m
+INFO [2022-09-08 10:48:14.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiLineString.swift[0m
+INFO [2022-09-08 10:48:14.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BoundingBox.swift[0m
+INFO [2022-09-08 10:48:14.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Codable.swift[0m
+INFO [2022-09-08 10:48:14.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreLocation.swift[0m
+INFO [2022-09-08 10:48:14.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RadianCoordinate2D.swift[0m
+INFO [2022-09-08 10:48:14.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Ring.swift[0m
+INFO [2022-09-08 10:48:14.51]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m YPImagePicker_YPImagePicker.bundle (in target 'YPImagePicker_YPImagePicker' from project 'YPImagePicker')[0m
+INFO [2022-09-08 10:48:14.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Spline.swift[0m
+INFO [2022-09-08 10:48:14.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Turf.swift[0m
+INFO [2022-09-08 10:48:14.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSON.swift[0m
+INFO [2022-09-08 10:48:14.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Geometry.swift[0m
+INFO [2022-09-08 10:48:14.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryCollection.swift[0m
+INFO [2022-09-08 10:48:14.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Point.swift[0m
+INFO [2022-09-08 10:48:14.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polygon.swift[0m
+INFO [2022-09-08 10:48:14.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TagListView.swift[0m
+INFO [2022-09-08 10:48:14.55]: ▸ [0;35;49m⚠️  [0m[0;35;49m/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/SourcePackages/checkouts/TagListView/TagListView/TagListView.swift:241:17: [0m[0;35;49munnecessary check for 'iOS'; enclosing scope ensures guard will always be true[0m
+INFO [2022-09-08 10:48:14.55]: ▸ [0;35;49m        else if #available(iOS 9.0, *) {[0m
+INFO [2022-09-08 10:48:14.55]: ▸ [0;35;49m                ^[0m
+INFO [2022-09-08 10:48:14.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TagView.swift[0m
+INFO [2022-09-08 10:48:14.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CloseButton.swift[0m
+INFO [2022-09-08 10:48:14.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EnvironmentValues+vibrancyEffectStyle.swift[0m
+INFO [2022-09-08 10:48:14.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m View+blurEffect.swift[0m
+INFO [2022-09-08 10:48:14.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m View+blurEffectStyle.swift[0m
+INFO [2022-09-08 10:48:14.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m View+vibrancyEffect.swift[0m
+INFO [2022-09-08 10:48:14.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VibrancyEffectStyleKey.swift[0m
+INFO [2022-09-08 10:48:14.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EnvironmentValues+blurEffectStyle.swift[0m
+INFO [2022-09-08 10:48:14.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m View+vibrancyEffectStyle.swift[0m
+INFO [2022-09-08 10:48:14.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BlurEffectModifier.swift[0m
+INFO [2022-09-08 10:48:14.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BlurEffect.swift[0m
+INFO [2022-09-08 10:48:14.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BlurEffectStyleKey.swift[0m
+INFO [2022-09-08 10:48:14.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BlurVisualEffectViewRepresentable.swift[0m
+INFO [2022-09-08 10:48:14.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VibrancyEffectModifier.swift[0m
+INFO [2022-09-08 10:48:14.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VibrancyVisualEffectViewRepresentable.swift[0m
+INFO [2022-09-08 10:48:14.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Alignment.swift[0m
+INFO [2022-09-08 10:48:14.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Baselines.swift[0m
+INFO [2022-09-08 10:48:14.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Center.swift[0m
+INFO [2022-09-08 10:48:14.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+LayoutAnchors.swift[0m
+INFO [2022-09-08 10:48:14.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Notifications.swift[0m
+INFO [2022-09-08 10:48:19.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m TagListView.o[0m
+INFO [2022-09-08 10:48:19.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPDeviceOrientationHelper.swift[0m
+INFO [2022-09-08 10:48:21.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPHelper.swift[0m
+INFO [2022-09-08 10:48:21.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLoaders.swift[0m
+INFO [2022-09-08 10:48:21.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLoadingView.swift[0m
+INFO [2022-09-08 10:48:21.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPPhotoSaver.swift[0m
+INFO [2022-09-08 10:48:21.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPVideoProcessor.swift[0m
+INFO [2022-09-08 10:48:21.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPDragDirection.swift[0m
+INFO [2022-09-08 10:48:21.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPError.swift[0m
+INFO [2022-09-08 10:48:21.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPFlashMode.swift[0m
+INFO [2022-09-08 10:48:21.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLibrarySelection.swift[0m
+INFO [2022-09-08 10:48:21.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLog.swift[0m
+INFO [2022-09-08 10:48:21.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m resource_bundle_accessor.swift[0m
+INFO [2022-09-08 10:48:21.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPColors.swift[0m
+INFO [2022-09-08 10:48:21.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPFonts.swift[0m
+INFO [2022-09-08 10:48:21.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPIcons.swift[0m
+INFO [2022-09-08 10:48:21.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPImagePickerConfiguration.swift[0m
+INFO [2022-09-08 10:48:21.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPImageSize.swift[0m
+INFO [2022-09-08 10:48:21.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPPickerScreen.swift[0m
+INFO [2022-09-08 10:48:21.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPWordings.swift[0m
+INFO [2022-09-08 10:48:21.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPCropVC.swift[0m
+INFO [2022-09-08 10:48:21.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPCropView.swift[0m
+INFO [2022-09-08 10:48:21.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPFilter.swift[0m
+INFO [2022-09-08 10:48:21.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LibraryMediaManager.swift[0m
+INFO [2022-09-08 10:48:23.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPAssetViewContainer.swift[0m
+INFO [2022-09-08 10:48:23.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPAssetZoomableView.swift[0m
+INFO [2022-09-08 10:48:23.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPGridView.swift[0m
+INFO [2022-09-08 10:48:23.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLibrary+LibraryChange.swift[0m
+INFO [2022-09-08 10:48:23.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLibraryVC+CollectionView.swift[0m
+INFO [2022-09-08 10:48:23.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLibraryVC+PanGesture.swift[0m
+INFO [2022-09-08 10:48:23.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLibraryVC.swift[0m
+INFO [2022-09-08 10:48:23.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLibraryView.swift[0m
+INFO [2022-09-08 10:48:23.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLibraryViewCell.swift[0m
+INFO [2022-09-08 10:48:23.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPLibraryViewDelegate.swift[0m
+INFO [2022-09-08 10:48:23.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIButton+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UICollectionView+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIColor+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIImage+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UINavigationBar+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m URL+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPPermissionCheckable.swift[0m
+INFO [2022-09-08 10:48:23.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPPermissionDeniedPopup.swift[0m
+INFO [2022-09-08 10:48:23.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPPermissionManager.swift[0m
+INFO [2022-09-08 10:48:23.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPAccessibility.swift[0m
+INFO [2022-09-08 10:48:23.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPAlerts.swift[0m
+INFO [2022-09-08 10:48:23.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPCameraVC.swift[0m
+INFO [2022-09-08 10:48:23.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPCameraView.swift[0m
+INFO [2022-09-08 10:48:23.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPPhotoCaptureHelper.swift[0m
+INFO [2022-09-08 10:48:23.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPVideoCaptureHelper.swift[0m
+INFO [2022-09-08 10:48:23.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPVideoCaptureVC.swift[0m
+INFO [2022-09-08 10:48:23.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPSelectionsGalleryCell.swift[0m
+INFO [2022-09-08 10:48:23.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPSelectionsGalleryVC.swift[0m
+INFO [2022-09-08 10:48:23.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPSelectionsGalleryView.swift[0m
+INFO [2022-09-08 10:48:23.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPImagePicker.swift[0m
+INFO [2022-09-08 10:48:23.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPPickerVC.swift[0m
+INFO [2022-09-08 10:48:23.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Turf[0m
+INFO [2022-09-08 10:48:23.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPFilterCollectionViewCell.swift[0m
+INFO [2022-09-08 10:48:23.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPFiltersView.swift[0m
+INFO [2022-09-08 10:48:23.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPPhotoFiltersVC.swift[0m
+INFO [2022-09-08 10:48:23.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPVideoFiltersVC.swift[0m
+INFO [2022-09-08 10:48:23.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPVideoView.swift[0m
+INFO [2022-09-08 10:48:23.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVAsset+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVCaptureDevice+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVCaptureSession+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVFileType+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVFoundation+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVMutableComposition+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVPlayer+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Bundle+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CGFloat+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CGRect+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CIImage+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IndexSet+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSFileManager+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PHCachingImageManager+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PHFetchResult+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIBarButtonItem+Extensions.swift[0m
+INFO [2022-09-08 10:48:23.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPMediaItem.swift[0m
+INFO [2022-09-08 10:48:23.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPTrimError.swift[0m
+INFO [2022-09-08 10:48:23.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPAlbum.swift[0m
+INFO [2022-09-08 10:48:23.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPAlbumCell.swift[0m
+INFO [2022-09-08 10:48:23.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPAlbumVC.swift[0m
+INFO [2022-09-08 10:48:23.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPAlbumView.swift[0m
+INFO [2022-09-08 10:48:23.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPAlbumsManager.swift[0m
+INFO [2022-09-08 10:48:23.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPBottomPager.swift[0m
+INFO [2022-09-08 10:48:23.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPBottomPagerView.swift[0m
+INFO [2022-09-08 10:48:23.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPMenuItem.swift[0m
+INFO [2022-09-08 10:48:23.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YPPagerMenu.swift[0m
+INFO [2022-09-08 10:48:23.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Stacks.swift[0m
+INFO [2022-09-08 10:48:23.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Style.swift[0m
+INFO [2022-09-08 10:48:23.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Operators.swift[0m
+INFO [2022-09-08 10:48:23.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Percentage.swift[0m
+INFO [2022-09-08 10:48:23.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m SwiftUIVisualEffects.o[0m
+INFO [2022-09-08 10:48:23.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Constraints.swift[0m
+INFO [2022-09-08 10:48:23.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Content.swift[0m
+INFO [2022-09-08 10:48:23.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+DoubleDash.swift[0m
+INFO [2022-09-08 10:48:23.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Equation.swift[0m
+INFO [2022-09-08 10:48:23.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Fill.swift[0m
+INFO [2022-09-08 10:48:23.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+FlexibleMargin.swift[0m
+INFO [2022-09-08 10:48:23.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+GetConstraint.swift[0m
+INFO [2022-09-08 10:48:23.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Hierarchy.swift[0m
+INFO [2022-09-08 10:48:23.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Position.swift[0m
+INFO [2022-09-08 10:48:23.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stevia+Size.swift[0m
+INFO [2022-09-08 10:48:23.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Solar_vers.c[0m
+INFO [2022-09-08 10:48:23.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Solar-dummy.m[0m
+INFO [2022-09-08 10:48:23.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Solar.swift[0m
+INFO [2022-09-08 10:48:23.95]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Turf.framework (in target 'Turf' from project 'Pods')[0m
+INFO [2022-09-08 10:48:23.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Recursive.swift[0m
+INFO [2022-09-08 10:48:23.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Swizzling.swift[0m
+INFO [2022-09-08 10:48:23.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RecoverableViewState.swift[0m
+INFO [2022-09-08 10:48:24.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonLayer.swift[0m
+INFO [2022-09-08 10:48:24.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonConfig.swift[0m
+INFO [2022-09-08 10:48:24.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonMultilinesLayerConfig.swift[0m
+INFO [2022-09-08 10:48:24.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GradientDirection+Animations.swift[0m
+INFO [2022-09-08 10:48:24.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PrepareViewForSkeleton.swift[0m
+INFO [2022-09-08 10:48:24.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+AppLifecycleNotifications.swift[0m
+INFO [2022-09-08 10:48:24.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+AssociatedObjects.swift[0m
+INFO [2022-09-08 10:48:24.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+CollectionSkeleton.swift[0m
+INFO [2022-09-08 10:48:24.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+Extensions.swift[0m
+INFO [2022-09-08 10:48:24.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+SkeletonView.swift[0m
+INFO [2022-09-08 10:48:24.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+Swizzling.swift[0m
+INFO [2022-09-08 10:48:24.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+Transitions.swift[0m
+INFO [2022-09-08 10:48:24.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonCollectionDelegate.swift[0m
+INFO [2022-09-08 10:48:24.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonReusableCell.swift[0m
+INFO [2022-09-08 10:48:24.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonDebug.swift[0m
+INFO [2022-09-08 10:48:24.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DispatchQueue+Extensions.swift[0m
+INFO [2022-09-08 10:48:24.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Int+Extensions.swift[0m
+INFO [2022-09-08 10:48:24.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notification+Extensions.swift[0m
+INFO [2022-09-08 10:48:24.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProcessInfo+Extensions.swift[0m
+INFO [2022-09-08 10:48:24.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AssociationPolicy.swift[0m
+INFO [2022-09-08 10:48:24.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonAnimationBuilder.swift[0m
+INFO [2022-09-08 10:48:24.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonAppearance.swift[0m
+INFO [2022-09-08 10:48:24.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonCollectionViewProtocols.swift[0m
+INFO [2022-09-08 10:48:24.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonTableViewProtocols.swift[0m
+INFO [2022-09-08 10:48:24.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Deprecated.swift[0m
+INFO [2022-09-08 10:48:24.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notification+SkeletonFlow.swift[0m
+INFO [2022-09-08 10:48:24.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GradientDirection.swift[0m
+INFO [2022-09-08 10:48:24.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonGradient.swift[0m
+INFO [2022-09-08 10:48:24.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonTextLineHeight.swift[0m
+INFO [2022-09-08 10:48:24.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonTextNumberOfLines.swift[0m
+INFO [2022-09-08 10:48:24.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonTransitionStyle.swift[0m
+INFO [2022-09-08 10:48:24.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonType.swift[0m
+INFO [2022-09-08 10:48:24.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonExtended.swift[0m
+INFO [2022-09-08 10:48:24.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonView.swift[0m
+INFO [2022-09-08 10:48:24.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CALayer+Animations.swift[0m
+INFO [2022-09-08 10:48:24.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UICollectionView+Extensions.swift[0m
+INFO [2022-09-08 10:48:24.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Recoverable.swift[0m
+INFO [2022-09-08 10:48:24.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonTextNode.swift[0m
+INFO [2022-09-08 10:48:24.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SubviewsSkeletonables.swift[0m
+INFO [2022-09-08 10:48:24.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonFlowHandler.swift[0m
+INFO [2022-09-08 10:48:24.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonLayerBuilder.swift[0m
+INFO [2022-09-08 10:48:24.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonMultilineLayerBuilder.swift[0m
+INFO [2022-09-08 10:48:24.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonTreeNode.swift[0m
+INFO [2022-09-08 10:48:24.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UILabel+IBInspectable.swift[0m
+INFO [2022-09-08 10:48:24.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UILabel+SKExtensions.swift[0m
+INFO [2022-09-08 10:48:24.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UITextView+IBInspectable.swift[0m
+INFO [2022-09-08 10:48:24.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UITextView+SKExtensions.swift[0m
+INFO [2022-09-08 10:48:24.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+IBInspectable.swift[0m
+INFO [2022-09-08 10:48:24.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+SKExtensions.swift[0m
+INFO [2022-09-08 10:48:24.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CollectionSkeleton.swift[0m
+INFO [2022-09-08 10:48:24.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonCollectionDataSource.swift[0m
+INFO [2022-09-08 10:48:24.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Stevia.o[0m
+INFO [2022-09-08 10:48:24.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CALayer+Extensions.swift[0m
+INFO [2022-09-08 10:48:24.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkeletonTreeNode+Extensions.swift[0m
+INFO [2022-09-08 10:48:24.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UICollectionView+CollectionSkeleton.swift[0m
+INFO [2022-09-08 10:48:24.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIColor+Skeleton.swift[0m
+INFO [2022-09-08 10:48:24.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UILabel+Extensions.swift[0m
+INFO [2022-09-08 10:48:24.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UITableView+CollectionSkeleton.swift[0m
+INFO [2022-09-08 10:48:24.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UITableView+Extensions.swift[0m
+INFO [2022-09-08 10:48:24.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Solar[0m
+INFO [2022-09-08 10:48:24.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RealFunctions.swift[0m
+INFO [2022-09-08 10:48:24.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Float80+Real.swift[0m
+INFO [2022-09-08 10:48:24.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Float+Real.swift[0m
+INFO [2022-09-08 10:48:24.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AlgebraicField.swift[0m
+INFO [2022-09-08 10:48:24.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ApproximateEquality.swift[0m
+INFO [2022-09-08 10:48:24.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Real.swift[0m
+INFO [2022-09-08 10:48:24.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Float16+Real.swift[0m
+INFO [2022-09-08 10:48:24.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AugmentedArithmetic.swift[0m
+INFO [2022-09-08 10:48:24.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Double+Real.swift[0m
+INFO [2022-09-08 10:48:24.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ElementaryFunctions.swift[0m
+INFO [2022-09-08 10:48:24.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RangeSeekSlider_vers.c[0m
+INFO [2022-09-08 10:48:24.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RangeSeekSlider-dummy.m[0m
+INFO [2022-09-08 10:48:24.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RangeSeekSliderDelegate.swift[0m
+INFO [2022-09-08 10:48:24.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TapticEngine.swift[0m
+INFO [2022-09-08 10:48:24.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RangeSeekSlider.swift[0m
+INFO [2022-09-08 10:48:24.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+constrainToParent.swift[0m
+INFO [2022-09-08 10:48:24.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PulleyPassthroughScrollView.swift[0m
+INFO [2022-09-08 10:48:24.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PulleyViewController.swift[0m
+INFO [2022-09-08 10:48:25.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIViewController+PulleyViewController.swift[0m
+INFO [2022-09-08 10:48:25.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VideoCropView.swift[0m
+INFO [2022-09-08 10:48:25.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AssetVideoScrollView.swift[0m
+INFO [2022-09-08 10:48:25.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVAssetTimeSelector.swift[0m
+INFO [2022-09-08 10:48:25.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m RealModule.o[0m
+INFO [2022-09-08 10:48:25.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HandlerView.swift[0m
+INFO [2022-09-08 10:48:26.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VideoScrollView.swift[0m
+INFO [2022-09-08 10:48:26.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CropMaskView.swift[0m
+INFO [2022-09-08 10:48:26.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PryntTrimmerView_vers.c[0m
+INFO [2022-09-08 10:48:26.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m SkeletonView.o[0m
+INFO [2022-09-08 10:48:26.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PryntTrimmerView-dummy.m[0m
+INFO [2022-09-08 10:48:26.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HandlerView.swift[0m
+INFO [2022-09-08 10:48:26.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VideoScrollView.swift[0m
+INFO [2022-09-08 10:48:26.02]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Solar.framework (in target 'Solar' from project 'Pods')[0m
+INFO [2022-09-08 10:48:26.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ThumbSelectorView.swift[0m
+INFO [2022-09-08 10:48:26.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVAssetTimeSelector.swift[0m
+INFO [2022-09-08 10:48:26.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AssetVideoScrollView.swift[0m
+INFO [2022-09-08 10:48:26.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PryntTrimmerView.swift[0m
+INFO [2022-09-08 10:48:26.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CropMaskView.swift[0m
+INFO [2022-09-08 10:48:26.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m RangeSeekSlider[0m
+INFO [2022-09-08 10:48:26.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VideoCropView.swift[0m
+INFO [2022-09-08 10:48:26.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m PryntTrimmerView.o[0m
+INFO [2022-09-08 10:48:26.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromises_vers.c[0m
+INFO [2022-09-08 10:48:26.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromiseError.m[0m
+INFO [2022-09-08 10:48:26.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise.m[0m
+INFO [2022-09-08 10:48:26.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Wrap.m[0m
+INFO [2022-09-08 10:48:26.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Validate.m[0m
+INFO [2022-09-08 10:48:26.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Timeout.m[0m
+INFO [2022-09-08 10:48:26.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Then.m[0m
+INFO [2022-09-08 10:48:26.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Testing.m[0m
+INFO [2022-09-08 10:48:26.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Retry.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Reduce.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Recover.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Race.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Do.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Delay.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Catch.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Await.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Async.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Any.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+Always.m[0m
+INFO [2022-09-08 10:48:26.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FBLPromise+All.m[0m
+INFO [2022-09-08 10:48:26.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m YPImagePicker.o[0m
+INFO [2022-09-08 10:48:26.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FBLPromises[0m
+INFO [2022-09-08 10:48:27.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m PryntTrimmerView[0m
+INFO [2022-09-08 10:48:27.39]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m RangeSeekSlider.framework (in target 'RangeSeekSlider' from project 'Pods')[0m
+INFO [2022-09-08 10:48:27.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline.swift[0m
+INFO [2022-09-08 10:48:29.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Pulley.o[0m
+INFO [2022-09-08 10:48:29.09]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FBLPromises.framework (in target 'PromisesObjC' from project 'Pods')[0m
+INFO [2022-09-08 10:48:29.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline.swift[0m
+INFO [2022-09-08 10:48:29.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreLocation.swift[0m
+INFO [2022-09-08 10:48:29.13]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m PryntTrimmerView.framework (in target 'PryntTrimmerView' from project 'Pods')[0m
+INFO [2022-09-08 10:48:29.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreLocation.swift[0m
+INFO [2022-09-08 10:48:29.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline.swift[0m
+INFO [2022-09-08 10:48:29.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreLocation.swift[0m
+INFO [2022-09-08 10:48:29.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline-library-watchOS9.0-dummy.m[0m
+INFO [2022-09-08 10:48:29.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline-library-watchOS9.0-dummy.m[0m
+INFO [2022-09-08 10:48:29.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline-library-watchOS9.0-dummy.m[0m
+INFO [2022-09-08 10:48:30.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline-library-watchOS7.1-dummy.m[0m
+INFO [2022-09-08 10:48:30.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline-library-watchOS7.1-dummy.m[0m
+INFO [2022-09-08 10:48:30.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline-library-watchOS7.1-dummy.m[0m
+INFO [2022-09-08 10:48:30.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline.swift[0m
+INFO [2022-09-08 10:48:30.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline.swift[0m
+INFO [2022-09-08 10:48:30.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPolyline-library-watchOS9.0.a[0m
+INFO [2022-09-08 10:48:30.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreLocation.swift[0m
+INFO [2022-09-08 10:48:30.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline.swift[0m
+INFO [2022-09-08 10:48:30.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPolyline-library-watchOS9.0.a[0m
+INFO [2022-09-08 10:48:30.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreLocation.swift[0m
+INFO [2022-09-08 10:48:30.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreLocation.swift[0m
+INFO [2022-09-08 10:48:30.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Polyline-framework-Info.plist[0m
+INFO [2022-09-08 10:48:30.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods-Watch-SE-dummy.m[0m
+INFO [2022-09-08 10:48:31.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m MapboxSpeech-Info.plist[0m
+INFO [2022-09-08 10:48:31.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m ImageViewer-Info.plist[0m
+INFO [2022-09-08 10:48:34.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPolyline-library-watchOS7.1.a[0m
+INFO [2022-09-08 10:48:34.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline.swift[0m
+INFO [2022-09-08 10:48:35.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPolyline-library-watchOS7.1.a[0m
+INFO [2022-09-08 10:48:35.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreLocation.swift[0m
+INFO [2022-09-08 10:48:35.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPolyline-library-watchOS9.0.a[0m
+INFO [2022-09-08 10:48:35.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m 'Copy generated compatibility header'[0m
+INFO [2022-09-08 10:48:35.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPolyline-library-watchOS7.1.a[0m
+INFO [2022-09-08 10:48:35.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVDataAsset.swift[0m
+INFO [2022-09-08 10:48:35.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Allocations.swift[0m
+INFO [2022-09-08 10:48:35.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Combine.swift[0m
+INFO [2022-09-08 10:48:35.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Deprecated.swift[0m
+INFO [2022-09-08 10:48:35.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Extensions.swift[0m
+INFO [2022-09-08 10:48:35.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Graphics.swift[0m
+INFO [2022-09-08 10:48:35.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageRequestKeys.swift[0m
+INFO [2022-09-08 10:48:35.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImagePipelineTask.swift[0m
+INFO [2022-09-08 10:48:35.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OperationTask.swift[0m
+INFO [2022-09-08 10:48:35.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TaskFetchDecodedImage.swift[0m
+INFO [2022-09-08 10:48:35.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TaskFetchOriginalImageData.swift[0m
+INFO [2022-09-08 10:48:35.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TaskFetchWithPublisher.swift[0m
+INFO [2022-09-08 10:48:35.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TaskLoadData.swift[0m
+INFO [2022-09-08 10:48:35.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TaskLoadImage.swift[0m
+INFO [2022-09-08 10:48:35.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m 'Copy generated compatibility header'[0m
+INFO [2022-09-08 10:48:35.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPods-Watch-SE.a[0m
+INFO [2022-09-08 10:48:35.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LinkedList.swift[0m
+INFO [2022-09-08 10:48:35.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Log.swift[0m
+INFO [2022-09-08 10:48:35.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Operation.swift[0m
+INFO [2022-09-08 10:48:35.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RateLimiter.swift[0m
+INFO [2022-09-08 10:48:35.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ResumableData.swift[0m
+INFO [2022-09-08 10:48:35.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FetchImage.swift[0m
+INFO [2022-09-08 10:48:35.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageViewExtensions.swift[0m
+INFO [2022-09-08 10:48:35.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DataLoading.swift[0m
+INFO [2022-09-08 10:48:35.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImagePrefetcher.swift[0m
+INFO [2022-09-08 10:48:35.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageDecompression.swift[0m
+INFO [2022-09-08 10:48:35.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageProcessing.swift[0m
+INFO [2022-09-08 10:48:35.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageProcessingOptions.swift[0m
+INFO [2022-09-08 10:48:35.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageProcessors+Anonymous.swift[0m
+INFO [2022-09-08 10:48:35.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageProcessors+Circle.swift[0m
+INFO [2022-09-08 10:48:35.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageProcessors+Composition.swift[0m
+INFO [2022-09-08 10:48:35.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageProcessors+CoreImage.swift[0m
+INFO [2022-09-08 10:48:35.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageProcessors+GaussianBlur.swift[0m
+INFO [2022-09-08 10:48:35.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageProcessors+Resize.swift[0m
+INFO [2022-09-08 10:48:35.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageProcessors+RoundedCorners.swift[0m
+INFO [2022-09-08 10:48:35.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageProcessors.swift[0m
+INFO [2022-09-08 10:48:35.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AsyncTask.swift[0m
+INFO [2022-09-08 10:48:35.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImagePublisher.swift[0m
+INFO [2022-09-08 10:48:35.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DataCache.swift[0m
+INFO [2022-09-08 10:48:35.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DataCaching.swift[0m
+INFO [2022-09-08 10:48:35.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageCache.swift[0m
+INFO [2022-09-08 10:48:35.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageCaching.swift[0m
+INFO [2022-09-08 10:48:35.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImagePipelineCache.swift[0m
+INFO [2022-09-08 10:48:35.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AssetType.swift[0m
+INFO [2022-09-08 10:48:35.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageDecoderRegistry.swift[0m
+INFO [2022-09-08 10:48:35.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods-Widget\ Extension\ Watch-dummy.m[0m
+INFO [2022-09-08 10:48:35.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods-Widget\ Extension\ Watch-dummy.m[0m
+INFO [2022-09-08 10:48:35.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageDecoders+Default.swift[0m
+INFO [2022-09-08 10:48:35.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageDecoders+Empty.swift[0m
+INFO [2022-09-08 10:48:35.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageDecoders+Video.swift[0m
+INFO [2022-09-08 10:48:35.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageDecoding.swift[0m
+INFO [2022-09-08 10:48:35.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageEncoders+Default.swift[0m
+INFO [2022-09-08 10:48:35.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageEncoders+ImageIO.swift[0m
+INFO [2022-09-08 10:48:35.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageEncoders.swift[0m
+INFO [2022-09-08 10:48:35.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageEncoding.swift[0m
+INFO [2022-09-08 10:48:35.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImagePipeline.swift[0m
+INFO [2022-09-08 10:48:35.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImagePipelineConfiguration.swift[0m
+INFO [2022-09-08 10:48:35.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImagePipelineDelegate.swift[0m
+INFO [2022-09-08 10:48:35.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageRequest.swift[0m
+INFO [2022-09-08 10:48:35.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageResponse.swift[0m
+INFO [2022-09-08 10:48:35.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageTask.swift[0m
+INFO [2022-09-08 10:48:35.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DataLoader.swift[0m
+INFO [2022-09-08 10:48:35.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m KeyType.swift[0m
+INFO [2022-09-08 10:48:35.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MarshalDictionary.swift[0m
+INFO [2022-09-08 10:48:35.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnmarshalUpdating.swift[0m
+INFO [2022-09-08 10:48:35.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Unmarshaling.swift[0m
+INFO [2022-09-08 10:48:35.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods-Watch-SE\ Extension-dummy.m[0m
+INFO [2022-09-08 10:48:35.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods-Watch-SE\ Extension-dummy.m[0m
+INFO [2022-09-08 10:48:35.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPods-Widget\ Extension\ Watch.a[0m
+INFO [2022-09-08 10:48:35.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ValueType.swift[0m
+INFO [2022-09-08 10:48:35.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline_vers.c[0m
+INFO [2022-09-08 10:48:35.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polyline-framework-dummy.m[0m
+INFO [2022-09-08 10:48:38.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Error.swift[0m
+INFO [2022-09-08 10:48:38.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m JSON.swift[0m
+INFO [2022-09-08 10:48:38.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Migration.swift[0m
+INFO [2022-09-08 10:48:38.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Operators.swift[0m
+INFO [2022-09-08 10:48:38.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPods-Widget\ Extension\ Watch.a[0m
+INFO [2022-09-08 10:48:38.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnmarshalingWithContext.swift[0m
+INFO [2022-09-08 10:48:38.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Nuke.o[0m
+INFO [2022-09-08 10:48:38.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MarshaledObject.swift[0m
+INFO [2022-09-08 10:48:38.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Marshaling.swift[0m
+INFO [2022-09-08 10:48:38.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxSpeech_vers.c[0m
+INFO [2022-09-08 10:48:38.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Pods-Widget\ Extension-umbrella.h[0m
+INFO [2022-09-08 10:48:38.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxSpeech-dummy.m[0m
+INFO [2022-09-08 10:48:38.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Check Pods Manifest.lock'[0m
+INFO [2022-09-08 10:48:38.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Widget\ Extension\ Watch.appex/ProximaNova-Xbold.otf[0m
+INFO [2022-09-08 10:48:38.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Widget\ Extension\ Watch.appex/ProximaNova-Semibold.otf[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Widget\ Extension\ Watch.appex/ProximaNova-RegIt.otf[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Widget\ Extension\ Watch.appex/ProximaNova-Reg.otf[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Widget\ Extension\ Watch.appex/ProximaNova-LightIt.otf[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Widget\ Extension\ Watch.appex/ProximaNova-Light.otf[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Widget\ Extension\ Watch.appex/ProximaNova-BoldIt.otf[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Widget\ Extension\ Watch.appex/ProximaNova-Bold.otf[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Widget\ Extension\ Watch.appex/ProximaNova-Black.otf[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Widget\ Extension\ Watch.appex/BikemapCore[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:38.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:38.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:38.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:38.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods-Widget\ Extension-dummy.m[0m
+INFO [2022-09-08 10:48:38.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods_Widget_Extension_vers.c[0m
+INFO [2022-09-08 10:48:38.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MBSpeechOptions.swift[0m
+INFO [2022-09-08 10:48:38.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxSpeech.swift[0m
+INFO [2022-09-08 10:48:38.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Keychain.swift[0m
+INFO [2022-09-08 10:48:38.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageViewer_vers.c[0m
+INFO [2022-09-08 10:48:40.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPods-Watch-SE\ Extension.a[0m
+INFO [2022-09-08 10:48:40.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mBuilding library[0m[0;35;49m libPods-Watch-SE\ Extension.a[0m
+INFO [2022-09-08 10:48:40.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Marshal.o[0m
+INFO [2022-09-08 10:48:40.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m String+Bikemap.swift[0m
+INFO [2022-09-08 10:48:41.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Widget_Extension.swift[0m
+INFO [2022-09-08 10:48:41.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager.swift[0m
+INFO [2022-09-08 10:48:41.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetLink.swift[0m
+INFO [2022-09-08 10:48:41.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CircularAccessoryView.swift[0m
+INFO [2022-09-08 10:48:41.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array+Bikemap.swift[0m
+INFO [2022-09-08 10:48:41.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LocationManager+BMWidget.swift[0m
+INFO [2022-09-08 10:48:41.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWidgetEntry.swift[0m
+INFO [2022-09-08 10:48:42.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Assets.swift[0m
+INFO [2022-09-08 10:48:42.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHistoryItem.swift[0m
+INFO [2022-09-08 10:48:42.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSONPointGeometry.swift[0m
+INFO [2022-09-08 10:48:42.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notification+Search.swift[0m
+INFO [2022-09-08 10:48:42.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikemapService.swift[0m
+INFO [2022-09-08 10:48:42.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnitConverter+Bikemap.swift[0m
+INFO [2022-09-08 10:48:42.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager+Support.swift[0m
+INFO [2022-09-08 10:48:42.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m MapboxDirections.h[0m
+INFO [2022-09-08 10:48:42.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m MapboxDirections-umbrella.h[0m
+INFO [2022-09-08 10:48:42.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Info.plist[0m
+INFO [2022-09-08 10:48:42.03]: ▸ [0;35;49m    [0m[0;35;49mTARGETED_DEVICE_FAMILY value (1,2) does not contain any device family values compatible with the watchOS platform. Please add the value '4' to the TARGETED_DEVICE_FAMILY build setting to indicate that this target supports the 'Apple Watch' device family. (in target 'Widget Extension Watch' from project 'Bikemap')[0m
+INFO [2022-09-08 10:48:42.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Config.swift[0m
+INFO [2022-09-08 10:48:42.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHistoryDataSource.swift[0m
+INFO [2022-09-08 10:48:42.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetButtons.swift[0m
+INFO [2022-09-08 10:48:42.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RectangularAccessoryView.swift[0m
+INFO [2022-09-08 10:48:42.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array+Bikemap.swift[0m
+INFO [2022-09-08 10:48:42.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LocationManager+BMWidget.swift[0m
+INFO [2022-09-08 10:48:42.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWidgetEntry.swift[0m
+INFO [2022-09-08 10:48:42.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Assets.swift[0m
+INFO [2022-09-08 10:48:42.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHistoryItem.swift[0m
+INFO [2022-09-08 10:48:42.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Fonts.swift[0m
+INFO [2022-09-08 10:48:42.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetButtonDetails.swift[0m
+INFO [2022-09-08 10:48:42.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CornerAccessoryView.swift[0m
+INFO [2022-09-08 10:48:42.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession.swift[0m
+INFO [2022-09-08 10:48:42.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProximaNovaFont.swift[0m
+INFO [2022-09-08 10:48:42.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSONPointGeometry.swift[0m
+INFO [2022-09-08 10:48:42.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notification+Search.swift[0m
+INFO [2022-09-08 10:48:42.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikemapService.swift[0m
+INFO [2022-09-08 10:48:42.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnitConverter+Bikemap.swift[0m
+INFO [2022-09-08 10:48:42.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager+Support.swift[0m
+INFO [2022-09-08 10:48:42.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Fonts.swift[0m
+INFO [2022-09-08 10:48:42.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetButtonDetails.swift[0m
+INFO [2022-09-08 10:48:42.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CornerAccessoryView.swift[0m
+INFO [2022-09-08 10:48:42.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession.swift[0m
+INFO [2022-09-08 10:48:42.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProximaNovaFont.swift[0m
+INFO [2022-09-08 10:48:42.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Widget\ Extension\ Watch_vers.c[0m
+INFO [2022-09-08 10:48:42.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Widget\ Extension\ Watch_vers.c[0m
+INFO [2022-09-08 10:48:42.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CLLocation+Bikemap.swift[0m
+INFO [2022-09-08 10:48:42.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetDeeplinks.swift[0m
+INFO [2022-09-08 10:48:42.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSensors.swift[0m
+INFO [2022-09-08 10:48:42.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProcessInfo+UITest.swift[0m
+INFO [2022-09-08 10:48:42.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession+Address.swift[0m
+INFO [2022-09-08 10:48:42.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsEvent.swift[0m
+INFO [2022-09-08 10:48:42.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InlineAccessoryView.swift[0m
+INFO [2022-09-08 10:48:42.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SharedUserDefaultsKeys.swift[0m
+INFO [2022-09-08 10:48:42.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWidgetAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:48:42.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CLLocation+Bikemap.swift[0m
+INFO [2022-09-08 10:48:42.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetDeeplinks.swift[0m
+INFO [2022-09-08 10:48:42.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSensors.swift[0m
+INFO [2022-09-08 10:48:42.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProcessInfo+UITest.swift[0m
+INFO [2022-09-08 10:48:42.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m String+Bikemap.swift[0m
+INFO [2022-09-08 10:48:43.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Widget_Extension.swift[0m
+INFO [2022-09-08 10:48:43.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager.swift[0m
+INFO [2022-09-08 10:48:43.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetLink.swift[0m
+INFO [2022-09-08 10:48:43.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CircularAccessoryView.swift[0m
+INFO [2022-09-08 10:48:43.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Color+BMWidget.swift[0m
+INFO [2022-09-08 10:48:43.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationRequest.swift[0m
+INFO [2022-09-08 10:48:43.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsService.swift[0m
+INFO [2022-09-08 10:48:43.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUITestAnalyticsEventData.swift[0m
+INFO [2022-09-08 10:48:43.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m log.swift[0m
+INFO [2022-09-08 10:48:43.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationSearchHistoryDataSource.swift[0m
+INFO [2022-09-08 10:48:43.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession+Address.swift[0m
+INFO [2022-09-08 10:48:43.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsEvent.swift[0m
+INFO [2022-09-08 10:48:43.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InlineAccessoryView.swift[0m
+INFO [2022-09-08 10:48:43.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SharedUserDefaultsKeys.swift[0m
+INFO [2022-09-08 10:48:43.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWidgetAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:48:43.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Color+BMWidget.swift[0m
+INFO [2022-09-08 10:48:43.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationRequest.swift[0m
+INFO [2022-09-08 10:48:43.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsService.swift[0m
+INFO [2022-09-08 10:48:43.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUITestAnalyticsEventData.swift[0m
+INFO [2022-09-08 10:48:43.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m log.swift[0m
+INFO [2022-09-08 10:48:43.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationSearchHistoryDataSource.swift[0m
+INFO [2022-09-08 10:48:43.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Config.swift[0m
+INFO [2022-09-08 10:48:43.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHistoryDataSource.swift[0m
+INFO [2022-09-08 10:48:43.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserDefaults.swift[0m
+INFO [2022-09-08 10:48:43.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetButtons.swift[0m
+INFO [2022-09-08 10:48:43.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RectangularAccessoryView.swift[0m
+INFO [2022-09-08 10:48:43.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageViewer-dummy.m[0m
+INFO [2022-09-08 10:48:43.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Polyline[0m
+INFO [2022-09-08 10:48:43.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m MapboxSpeech[0m
+INFO [2022-09-08 10:48:43.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m KeychainAccess.o[0m
+INFO [2022-09-08 10:48:43.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GalleryItem.swift[0m
+INFO [2022-09-08 10:48:43.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GalleryItemsDataSource.swift[0m
+INFO [2022-09-08 10:48:43.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GalleryItemsDelegate.swift[0m
+INFO [2022-09-08 10:48:43.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GalleryPagingDataSource.swift[0m
+INFO [2022-09-08 10:48:43.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GallerySwipeToDismissTransition.swift[0m
+INFO [2022-09-08 10:48:43.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GalleryViewController.swift[0m
+INFO [2022-09-08 10:48:45.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageFadeInHandler.swift[0m
+INFO [2022-09-08 10:48:45.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageViewController.swift[0m
+INFO [2022-09-08 10:48:45.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ItemBaseController.swift[0m
+INFO [2022-09-08 10:48:45.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ItemController.swift[0m
+INFO [2022-09-08 10:48:45.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CGPoint.swift[0m
+INFO [2022-09-08 10:48:45.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CGRect.swift[0m
+INFO [2022-09-08 10:48:45.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CGSize.swift[0m
+INFO [2022-09-08 10:48:45.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GalleryConfiguration.swift[0m
+INFO [2022-09-08 10:48:45.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GalleryDisplacedViewsDataSource.swift[0m
+INFO [2022-09-08 10:48:45.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ItemControllerDelegate.swift[0m
+INFO [2022-09-08 10:48:45.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LayoutEnums.swift[0m
+INFO [2022-09-08 10:48:45.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Slider.swift[0m
+INFO [2022-09-08 10:48:45.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ThumbnailCell.swift[0m
+INFO [2022-09-08 10:48:45.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ThumbnailsViewController.swift[0m
+INFO [2022-09-08 10:48:45.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UtilityFunctions.swift[0m
+INFO [2022-09-08 10:48:45.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VideoScrubber.swift[0m
+INFO [2022-09-08 10:48:45.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VideoView.swift[0m
+INFO [2022-09-08 10:48:45.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VideoViewController.swift[0m
+INFO [2022-09-08 10:48:45.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIApplication.swift[0m
+INFO [2022-09-08 10:48:45.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIBezierPath.swift[0m
+INFO [2022-09-08 10:48:45.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIButton.swift[0m
+INFO [2022-09-08 10:48:45.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIColor.swift[0m
+INFO [2022-09-08 10:48:45.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIImageView.swift[0m
+INFO [2022-09-08 10:48:45.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIScreen.swift[0m
+INFO [2022-09-08 10:48:45.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UISlider.swift[0m
+INFO [2022-09-08 10:48:45.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView.swift[0m
+INFO [2022-09-08 10:48:45.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIViewController.swift[0m
+INFO [2022-09-08 10:48:45.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Widget\[0m
+INFO [2022-09-08 10:48:45.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteRefreshResponse.swift[0m
+INFO [2022-09-08 10:48:46.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteResponse.swift[0m
+INFO [2022-09-08 10:48:46.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteStep.swift[0m
+INFO [2022-09-08 10:48:46.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SpokenInstruction.swift[0m
+INFO [2022-09-08 10:48:46.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m String.swift[0m
+INFO [2022-09-08 10:48:46.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TollCollection.swift[0m
+INFO [2022-09-08 10:48:46.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AdministrativeRegion.swift[0m
+INFO [2022-09-08 10:48:46.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array.swift[0m
+INFO [2022-09-08 10:48:46.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AttributeOptions.swift[0m
+INFO [2022-09-08 10:48:46.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BlockedLanes.swift[0m
+INFO [2022-09-08 10:48:46.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Codable.swift[0m
+INFO [2022-09-08 10:48:46.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Congestion.swift[0m
+INFO [2022-09-08 10:48:46.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Intersection.swift[0m
+INFO [2022-09-08 10:48:46.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Lane.swift[0m
+INFO [2022-09-08 10:48:46.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LaneIndication.swift[0m
+INFO [2022-09-08 10:48:46.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxStreetsRoadClass.swift[0m
+INFO [2022-09-08 10:48:46.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapMatchingResponse.swift[0m
+INFO [2022-09-08 10:48:46.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Match.swift[0m
+INFO [2022-09-08 10:48:46.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreLocation.swift[0m
+INFO [2022-09-08 10:48:46.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Directions.swift[0m
+INFO [2022-09-08 10:48:46.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DirectionsCredentials.swift[0m
+INFO [2022-09-08 10:48:46.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DirectionsError.swift[0m
+INFO [2022-09-08 10:48:46.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DirectionsOptions.swift[0m
+INFO [2022-09-08 10:48:46.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DirectionsProfileIdentifier.swift[0m
+INFO [2022-09-08 10:48:46.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DirectionsResult.swift[0m
+INFO [2022-09-08 10:48:46.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Double.swift[0m
+INFO [2022-09-08 10:48:46.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DrivingSide.swift[0m
+INFO [2022-09-08 10:48:46.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSON.swift[0m
+INFO [2022-09-08 10:48:46.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HTTPURLResponse.swift[0m
+INFO [2022-09-08 10:48:46.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Incident.swift[0m
+INFO [2022-09-08 10:48:46.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Widget\[0m
+INFO [2022-09-08 10:48:46.37]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Polyline.framework (in target 'Polyline-framework' from project 'Pods')[0m
+INFO [2022-09-08 10:48:46.37]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m MapboxSpeech.framework (in target 'MapboxSpeech' from project 'Pods')[0m
+INFO [2022-09-08 10:48:46.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Pods-Widget Extension-Info.plist[0m
+INFO [2022-09-08 10:48:46.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m MapboxDirections-Info.plist[0m
+INFO [2022-09-08 10:48:46.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RestStop.swift[0m
+INFO [2022-09-08 10:48:46.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RoadClasses.swift[0m
+INFO [2022-09-08 10:48:46.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route.swift[0m
+INFO [2022-09-08 10:48:46.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteLeg.swift[0m
+INFO [2022-09-08 10:48:46.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteLegAttributes.swift[0m
+INFO [2022-09-08 10:48:46.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteOptions.swift[0m
+INFO [2022-09-08 10:48:46.71]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Widget\ Extension\ Watch.appex (in target 'Widget Extension Watch' from project 'Bikemap')[0m
+INFO [2022-09-08 10:48:46.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Tracepoint.swift[0m
+INFO [2022-09-08 10:48:46.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VisualInstruction.swift[0m
+INFO [2022-09-08 10:48:46.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VisualInstructionBanner.swift[0m
+INFO [2022-09-08 10:48:46.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VisualInstructionComponent.swift[0m
+INFO [2022-09-08 10:48:46.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Waypoint.swift[0m
+INFO [2022-09-08 10:48:46.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MatchOptions.swift[0m
+INFO [2022-09-08 10:48:46.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Measurement.swift[0m
+INFO [2022-09-08 10:48:46.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineDirections.swift[0m
+INFO [2022-09-08 10:48:46.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m QuickLook.swift[0m
+INFO [2022-09-08 10:48:46.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RefreshedRoute.swift[0m
+INFO [2022-09-08 10:48:46.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ResponseDisposition.swift[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Pods_Widget_Extension.framework (in target 'Pods-Widget Extension' from project 'Pods')[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Check Pods Manifest.lock'[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Widget\ Extension.appex/ProximaNova-Xbold.otf[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Widget\ Extension.appex/ProximaNova-Semibold.otf[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Widget\ Extension.appex/ProximaNova-RegIt.otf[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Widget\ Extension.appex/ProximaNova-Reg.otf[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Widget\ Extension.appex/ProximaNova-LightIt.otf[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Widget\ Extension.appex/ProximaNova-Light.otf[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Widget\ Extension.appex/ProximaNova-BoldIt.otf[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Widget\ Extension.appex/ProximaNova-Bold.otf[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Widget\ Extension.appex/ProximaNova-Black.otf[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Widget\ Extension.appex/BikemapCore[0m
+INFO [2022-09-08 10:48:46.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxDirections_vers.c[0m
+INFO [2022-09-08 10:48:46.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxDirections-dummy.m[0m
+INFO [2022-09-08 10:48:46.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVPlayer.swift[0m
+INFO [2022-09-08 10:48:46.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BlurView.swift[0m
+INFO [2022-09-08 10:48:46.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Bool.swift[0m
+INFO [2022-09-08 10:48:46.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CALayer.swift[0m
+INFO [2022-09-08 10:48:46.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CAShapeLayer.swift[0m
+INFO [2022-09-08 10:48:46.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/zh_TW.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/zh_CN.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/vi.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/uk.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/tr.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/th.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/sv.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/sk.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/ru.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/ro.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/pt_PT.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/pt_BR.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/pt.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/pl.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/nl.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/nb.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/ms.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/ko.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/ja.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/it.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/id.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/hu.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/hr.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/hi.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/he.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/google@3x.png[0m
+INFO [2022-09-08 10:48:46.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/google@2x.png[0m
+INFO [2022-09-08 10:48:50.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Config.swift[0m
+INFO [2022-09-08 10:48:50.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHistoryDataSource.swift[0m
+INFO [2022-09-08 10:48:50.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserDefaults.swift[0m
+INFO [2022-09-08 10:48:50.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetButtons.swift[0m
+INFO [2022-09-08 10:48:50.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RectangularAccessoryView.swift[0m
+INFO [2022-09-08 10:48:51.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Fonts.swift[0m
+INFO [2022-09-08 10:48:51.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetButtonDetails.swift[0m
+INFO [2022-09-08 10:48:51.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CornerAccessoryView.swift[0m
+INFO [2022-09-08 10:48:51.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession.swift[0m
+INFO [2022-09-08 10:48:51.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProximaNovaFont.swift[0m
+INFO [2022-09-08 10:48:51.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CLLocation+Bikemap.swift[0m
+INFO [2022-09-08 10:48:51.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Double+Bikemap.swift[0m
+INFO [2022-09-08 10:48:51.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetDeeplinks.swift[0m
+INFO [2022-09-08 10:48:51.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSensors.swift[0m
+INFO [2022-09-08 10:48:51.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProcessInfo+UITest.swift[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m MapboxCoreNavigation.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m MapboxCoreNavigation-umbrella.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m MBXPeerWrapper.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m NSURLSession+GULPromises.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GoogleUtilities-umbrella.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULUserDefaults.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULURLSessionDataResponse.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULSwizzler.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULSecureCoding.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULSceneDelegateSwizzler.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULReachabilityChecker.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULOriginalIMPConvenienceMacros.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULNetworkURLSession.h[0m
+INFO [2022-09-08 10:48:51.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULNetworkMessageCode.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULNetworkLoggerProtocol.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULNetworkConstants.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULNetwork.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULNSData+zlib.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULMutableDictionary.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULLoggerLevel.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULLogger.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULKeychainUtils.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULKeychainStorage.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULHeartbeatDateStorageUserDefaults.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULHeartbeatDateStorage.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULHeartbeatDateStorable.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULApplication.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULAppEnvironmentUtil.h[0m
+INFO [2022-09-08 10:48:51.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GULAppDelegateSwizzler.h[0m
+INFO [2022-09-08 10:48:51.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Color+BMWidget.swift[0m
+INFO [2022-09-08 10:48:51.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationRequest.swift[0m
+INFO [2022-09-08 10:48:51.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsService.swift[0m
+INFO [2022-09-08 10:48:51.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUITestAnalyticsEventData.swift[0m
+INFO [2022-09-08 10:48:51.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m log.swift[0m
+INFO [2022-09-08 10:48:51.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationSearchHistoryDataSource.swift[0m
+INFO [2022-09-08 10:48:51.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession+Address.swift[0m
+INFO [2022-09-08 10:48:51.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsEvent.swift[0m
+INFO [2022-09-08 10:48:51.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InlineAccessoryView.swift[0m
+INFO [2022-09-08 10:48:51.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SharedUserDefaultsKeys.swift[0m
+INFO [2022-09-08 10:48:51.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWidgetAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:48:51.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Info.plist[0m
+INFO [2022-09-08 10:48:51.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array+Bikemap.swift[0m
+INFO [2022-09-08 10:48:51.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LocationManager+BMWidget.swift[0m
+INFO [2022-09-08 10:48:51.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWidgetEntry.swift[0m
+INFO [2022-09-08 10:48:51.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Assets.swift[0m
+INFO [2022-09-08 10:48:51.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHistoryItem.swift[0m
+INFO [2022-09-08 10:48:51.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSONPointGeometry.swift[0m
+INFO [2022-09-08 10:48:51.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notification+Search.swift[0m
+INFO [2022-09-08 10:48:51.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikemapService.swift[0m
+INFO [2022-09-08 10:48:51.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnitConverter+Bikemap.swift[0m
+INFO [2022-09-08 10:48:51.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager+Support.swift[0m
+INFO [2022-09-08 10:48:51.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m String+Bikemap.swift[0m
+INFO [2022-09-08 10:48:52.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Widget_Extension.swift[0m
+INFO [2022-09-08 10:48:52.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager.swift[0m
+INFO [2022-09-08 10:48:52.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WidgetLink.swift[0m
+INFO [2022-09-08 10:48:52.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CircularAccessoryView.swift[0m
+INFO [2022-09-08 10:48:52.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m GoogleUtilities-Info.plist[0m
+INFO [2022-09-08 10:48:52.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSURLSession+GULPromises.m[0m
+INFO [2022-09-08 10:48:55.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m MapboxDirections[0m
+INFO [2022-09-08 10:48:55.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m ImageViewer[0m
+INFO [2022-09-08 10:48:55.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GoogleUtilities_vers.c[0m
+INFO [2022-09-08 10:48:55.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Widget\ Extension_vers.c[0m
+INFO [2022-09-08 10:48:55.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GoogleUtilities-dummy.m[0m
+INFO [2022-09-08 10:48:55.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULUserDefaults.m[0m
+INFO [2022-09-08 10:48:55.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULURLSessionDataResponse.m[0m
+INFO [2022-09-08 10:48:55.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULSwizzler.m[0m
+INFO [2022-09-08 10:48:55.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULSecureCoding.m[0m
+INFO [2022-09-08 10:48:55.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULSceneDelegateSwizzler.m[0m
+INFO [2022-09-08 10:48:55.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Widget\[0m
+INFO [2022-09-08 10:48:55.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PassiveLocationDataSource.swift[0m
+INFO [2022-09-08 10:48:55.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProcessInfo.swift[0m
+INFO [2022-09-08 10:48:55.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ReplayLocationManager.swift[0m
+INFO [2022-09-08 10:48:55.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RestStop.swift[0m
+INFO [2022-09-08 10:48:55.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteAlert.swift[0m
+INFO [2022-09-08 10:48:55.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteController.swift[0m
+INFO [2022-09-08 10:48:55.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DispatchTimer.swift[0m
+INFO [2022-09-08 10:48:55.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DistanceFormatter.swift[0m
+INFO [2022-09-08 10:48:55.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EndOfRouteFeedback.swift[0m
+INFO [2022-09-08 10:48:55.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EventDetails.swift[0m
+INFO [2022-09-08 10:48:55.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Feedback.swift[0m
+INFO [2022-09-08 10:48:55.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FixLocation.swift[0m
+INFO [2022-09-08 10:48:55.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Incident.swift[0m
+INFO [2022-09-08 10:48:55.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BorderCrossing.swift[0m
+INFO [2022-09-08 10:48:55.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BundleAdditions.swift[0m
+INFO [2022-09-08 10:48:55.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CLLocation.swift[0m
+INFO [2022-09-08 10:48:55.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CLLocationDirection.swift[0m
+INFO [2022-09-08 10:48:55.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreConstants.swift[0m
+INFO [2022-09-08 10:48:55.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreFeedbackEvent.swift[0m
+INFO [2022-09-08 10:48:55.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Date.swift[0m
+INFO [2022-09-08 10:48:55.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LegacyRouteController.swift[0m
+INFO [2022-09-08 10:48:55.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Locale.swift[0m
+INFO [2022-09-08 10:48:55.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MinimumEditDistance.swift[0m
+INFO [2022-09-08 10:48:55.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MMEEventsManager.swift[0m
+INFO [2022-09-08 10:48:55.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationEventsManager.swift[0m
+INFO [2022-09-08 10:48:55.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationLocationManager.swift[0m
+INFO [2022-09-08 10:48:55.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteState.swift[0m
+INFO [2022-09-08 10:48:55.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteStep.swift[0m
+INFO [2022-09-08 10:48:55.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteStepProgress.swift[0m
+INFO [2022-09-08 10:48:55.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ScreenCapture.swift[0m
+INFO [2022-09-08 10:48:55.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SessionState.swift[0m
+INFO [2022-09-08 10:48:55.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimulatedLocationManager.swift[0m
+INFO [2022-09-08 10:48:55.37]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Widget\ Extension.appex (in target 'Widget Extension' from project 'Bikemap')[0m
+INFO [2022-09-08 10:48:55.37]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m MapboxDirections.framework (in target 'MapboxDirections' from project 'Pods')[0m
+INFO [2022-09-08 10:48:55.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m MapboxCoreNavigation-Info.plist[0m
+INFO [2022-09-08 10:48:55.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m MapboxNavigation.h[0m
+INFO [2022-09-08 10:48:55.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m MapboxNavigation-umbrella.h[0m
+INFO [2022-09-08 10:48:55.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m MGLMapView+MGLNavigationAdditions.h[0m
+INFO [2022-09-08 10:48:55.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m CLLocationManager+MGLNavigationAdditions.h[0m
+INFO [2022-09-08 10:48:55.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxCoreNavigation_vers.c[0m
+INFO [2022-09-08 10:48:55.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxCoreNavigation-dummy.m[0m
+INFO [2022-09-08 10:48:55.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SkuTokenProvider.swift[0m
+INFO [2022-09-08 10:48:55.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TollCollection.swift[0m
+INFO [2022-09-08 10:48:55.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Tunnel.swift[0m
+INFO [2022-09-08 10:48:55.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TunnelAuthority.swift[0m
+INFO [2022-09-08 10:48:55.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnimplementedLogging.swift[0m
+INFO [2022-09-08 10:48:55.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m URLSession.swift[0m
+INFO [2022-09-08 10:48:55.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationRouteOptions.swift[0m
+INFO [2022-09-08 10:48:55.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationService.swift[0m
+INFO [2022-09-08 10:48:55.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationServiceDelegate.swift[0m
+INFO [2022-09-08 10:48:55.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationSettings.swift[0m
+INFO [2022-09-08 10:48:55.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Navigator.swift[0m
+INFO [2022-09-08 10:48:55.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineDirections.swift[0m
+INFO [2022-09-08 10:48:55.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteLeg.swift[0m
+INFO [2022-09-08 10:48:55.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteLegProgress.swift[0m
+INFO [2022-09-08 10:48:55.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteOptions.swift[0m
+INFO [2022-09-08 10:48:55.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteProgress.swift[0m
+INFO [2022-09-08 10:48:55.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Router.swift[0m
+INFO [2022-09-08 10:48:55.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouterDelegate.swift[0m
+INFO [2022-09-08 10:48:55.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULReachabilityChecker.m[0m
+INFO [2022-09-08 10:48:55.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULNetworkURLSession.m[0m
+INFO [2022-09-08 10:48:55.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULNetworkConstants.m[0m
+INFO [2022-09-08 10:48:55.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULNetwork.m[0m
+INFO [2022-09-08 10:48:55.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULNSData+zlib.m[0m
+INFO [2022-09-08 10:48:55.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULMutableDictionary.m[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULLogger.m[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULKeychainUtils.m[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULKeychainStorage.m[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULHeartbeatDateStorageUserDefaults.m[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULHeartbeatDateStorage.m[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULAppEnvironmentUtil.m[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GULAppDelegateSwizzler.m[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m empty-GoogleSignIn_GoogleSignIn.plist[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/google.png[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m ImageViewer.framework (in target 'ImageViewer' from project 'Pods')[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/fr_CA.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/fr.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/fi.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/es_MX.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/es.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/en_GB.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/en.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/el.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/de.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/da.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/cs.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/ca.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/ar.lproj/GoogleSignIn.strings[0m
+INFO [2022-09-08 10:48:55.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/GoogleSignIn_GoogleSignIn.bundle/Roboto-Bold.ttf[0m
+INFO [2022-09-08 10:48:55.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSBundle+GID3PAdditions.m[0m
+INFO [2022-09-08 10:48:59.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m resource_bundle_accessor.m[0m
+INFO [2022-09-08 10:48:59.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDSignInStrings.m[0m
+INFO [2022-09-08 10:48:59.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDSignInPreferences.m[0m
+INFO [2022-09-08 10:48:59.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDSignInInternalOptions.m[0m
+INFO [2022-09-08 10:48:59.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m GoogleUtilities[0m
+INFO [2022-09-08 10:48:59.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDSignInCallbackSchemes.m[0m
+INFO [2022-09-08 10:48:59.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSAttributedString.swift[0m
+INFO [2022-09-08 10:49:00.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PassiveLocationManager.swift[0m
+INFO [2022-09-08 10:49:00.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RatingControl.swift[0m
+INFO [2022-09-08 10:49:00.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RecentItem.swift[0m
+INFO [2022-09-08 10:49:00.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route.swift[0m
+INFO [2022-09-08 10:49:00.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteMapViewController.swift[0m
+INFO [2022-09-08 10:49:00.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteVoiceController.swift[0m
+INFO [2022-09-08 10:49:00.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SpeechSynthesizing.swift[0m
+INFO [2022-09-08 10:49:00.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SpeedLimitStyleKit.swift[0m
+INFO [2022-09-08 10:49:00.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SpeedLimitView.swift[0m
+INFO [2022-09-08 10:49:00.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StatusView.swift[0m
+INFO [2022-09-08 10:49:00.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StepsViewController.swift[0m
+INFO [2022-09-08 10:49:00.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array.swift[0m
+INFO [2022-09-08 10:49:00.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AVAudioSession.swift[0m
+INFO [2022-09-08 10:49:00.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BottomBannerViewController.swift[0m
+INFO [2022-09-08 10:49:00.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BottomBannerViewLayout.swift[0m
+INFO [2022-09-08 10:49:00.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Bundle.swift[0m
+INFO [2022-09-08 10:49:00.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Cache.swift[0m
+INFO [2022-09-08 10:49:00.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CGPoint.swift[0m
+INFO [2022-09-08 10:49:00.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CGSize.swift[0m
+INFO [2022-09-08 10:49:00.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Constants.swift[0m
+INFO [2022-09-08 10:49:00.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Constants+InstructionsCard.swift[0m
+INFO [2022-09-08 10:49:00.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DataCache.swift[0m
+INFO [2022-09-08 10:49:00.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DateComponentsFormatter+MGLNavigationAdditions.swift[0m
+INFO [2022-09-08 10:49:00.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DayStyle.swift[0m
+INFO [2022-09-08 10:49:00.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m String.swift[0m
+INFO [2022-09-08 10:49:00.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Style.swift[0m
+INFO [2022-09-08 10:49:00.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StyleKitMarker.swift[0m
+INFO [2022-09-08 10:49:00.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StyleManager.swift[0m
+INFO [2022-09-08 10:49:00.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StyleType.swift[0m
+INFO [2022-09-08 10:49:00.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SystemSpeechSynthesizer.swift[0m
+INFO [2022-09-08 10:49:00.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TopBannerViewController.swift[0m
+INFO [2022-09-08 10:49:00.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Transitioning.swift[0m
+INFO [2022-09-08 10:49:00.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Turf.swift[0m
+INFO [2022-09-08 10:49:00.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UICollectionView.swift[0m
+INFO [2022-09-08 10:49:00.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIDevice.swift[0m
+INFO [2022-09-08 10:49:00.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIEdgeInsets.swift[0m
+INFO [2022-09-08 10:49:00.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DialogViewController.swift[0m
+INFO [2022-09-08 10:49:00.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Dictionary.swift[0m
+INFO [2022-09-08 10:49:00.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EndOfRouteViewController.swift[0m
+INFO [2022-09-08 10:49:00.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Error.swift[0m
+INFO [2022-09-08 10:49:00.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ExitView.swift[0m
+INFO [2022-09-08 10:49:00.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FeedbackCollectionViewCell.swift[0m
+INFO [2022-09-08 10:49:00.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FeedbackItem.swift[0m
+INFO [2022-09-08 10:49:00.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FeedbackSubtypeCollectionViewCell.swift[0m
+INFO [2022-09-08 10:49:00.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FeedbackSubtypeViewController.swift[0m
+INFO [2022-09-08 10:49:00.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FeedbackViewController.swift[0m
+INFO [2022-09-08 10:49:00.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GenericRouteShield.swift[0m
+INFO [2022-09-08 10:49:00.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HighwayShield.swift[0m
+INFO [2022-09-08 10:49:00.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m JunctionView.swift[0m
+INFO [2022-09-08 10:49:01.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LanesStyleKit.swift[0m
+INFO [2022-09-08 10:49:01.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LanesView.swift[0m
+INFO [2022-09-08 10:49:01.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LaneView.swift[0m
+INFO [2022-09-08 10:49:01.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ManeuversStyleKit.swift[0m
+INFO [2022-09-08 10:49:01.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ManeuverView.swift[0m
+INFO [2022-09-08 10:49:01.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxSpeechSynthesizer.swift[0m
+INFO [2022-09-08 10:49:01.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Match.swift[0m
+INFO [2022-09-08 10:49:01.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLMapView.swift[0m
+INFO [2022-09-08 10:49:01.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLShape.swift[0m
+INFO [2022-09-08 10:49:01.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLStyle.swift[0m
+INFO [2022-09-08 10:49:01.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLVectorTileSource.swift[0m
+INFO [2022-09-08 10:49:01.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIFont.swift[0m
+INFO [2022-09-08 10:49:01.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIGestureRecognizer.swift[0m
+INFO [2022-09-08 10:49:01.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIImage.swift[0m
+INFO [2022-09-08 10:49:01.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIStackView.swift[0m
+INFO [2022-09-08 10:49:01.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView.swift[0m
+INFO [2022-09-08 10:49:01.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIViewController.swift[0m
+INFO [2022-09-08 10:49:01.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserCourseView.swift[0m
+INFO [2022-09-08 10:49:01.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserHaloCourseView.swift[0m
+INFO [2022-09-08 10:49:01.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VanishingRouteLine.swift[0m
+INFO [2022-09-08 10:49:01.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VisualInstruction.swift[0m
+INFO [2022-09-08 10:49:01.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VisualInstructionComponent.swift[0m
+INFO [2022-09-08 10:49:01.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WaypointStyle.swift[0m
+INFO [2022-09-08 10:49:01.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageCache.swift[0m
+INFO [2022-09-08 10:49:02.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageDownload.swift[0m
+INFO [2022-09-08 10:49:02.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageDownloader.swift[0m
+INFO [2022-09-08 10:49:02.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageRepository.swift[0m
+INFO [2022-09-08 10:49:02.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InstructionLabel.swift[0m
+INFO [2022-09-08 10:49:02.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InstructionPresenter.swift[0m
+INFO [2022-09-08 10:49:02.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InstructionsBannerView.swift[0m
+INFO [2022-09-08 10:49:02.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InstructionsCardCell.swift[0m
+INFO [2022-09-08 10:49:02.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InstructionsCardCollectionDelegate.swift[0m
+INFO [2022-09-08 10:49:02.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InstructionsCardContainerView.swift[0m
+INFO [2022-09-08 10:49:02.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InstructionsCardView.swift[0m
+INFO [2022-09-08 10:49:02.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InstructionsCardViewController.swift[0m
+INFO [2022-09-08 10:49:02.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiplexedSpeechSynthesizer.swift[0m
+INFO [2022-09-08 10:49:04.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationComponent.swift[0m
+INFO [2022-09-08 10:49:04.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationCustomizable.swift[0m
+INFO [2022-09-08 10:49:04.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationMapView.swift[0m
+INFO [2022-09-08 10:49:04.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationMapViewDelegate.swift[0m
+INFO [2022-09-08 10:49:04.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationOptions.swift[0m
+INFO [2022-09-08 10:49:04.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationView.swift[0m
+INFO [2022-09-08 10:49:04.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationViewController.swift[0m
+INFO [2022-09-08 10:49:04.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationViewControllerDelegate.swift[0m
+INFO [2022-09-08 10:49:04.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationViewLayout.swift[0m
+INFO [2022-09-08 10:49:04.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NextBannerView.swift[0m
+INFO [2022-09-08 10:49:04.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NightStyle.swift[0m
+INFO [2022-09-08 10:49:04.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m MapboxCoreNavigation[0m
+INFO [2022-09-08 10:49:04.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxNavigation_vers.c[0m
+INFO [2022-09-08 10:49:04.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxNavigation-dummy.m[0m
+INFO [2022-09-08 10:49:04.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLMapView+MGLNavigationAdditions.m[0m
+INFO [2022-09-08 10:49:04.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDSignInButton.m[0m
+INFO [2022-09-08 10:49:04.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDSignIn.m[0m
+INFO [2022-09-08 10:49:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDScopes.m[0m
+INFO [2022-09-08 10:49:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDProfileData.m[0m
+INFO [2022-09-08 10:49:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDMDMPasscodeState.m[0m
+INFO [2022-09-08 10:49:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDMDMPasscodeCache.m[0m
+INFO [2022-09-08 10:49:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDGoogleUser.m[0m
+INFO [2022-09-08 10:49:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDEMMErrorHandler.m[0m
+INFO [2022-09-08 10:49:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDConfiguration.m[0m
+INFO [2022-09-08 10:49:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDCallbackQueue.m[0m
+INFO [2022-09-08 10:49:04.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDAuthentication.m[0m
+INFO [2022-09-08 10:49:04.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIDAuthStateMigration.m[0m
+INFO [2022-09-08 10:49:04.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GTMOAuth2KeychainCompatibility.m[0m
+INFO [2022-09-08 10:49:04.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GTMKeychain.m[0m
+INFO [2022-09-08 10:49:04.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GTMAppAuthFetcherAuthorization.m[0m
+INFO [2022-09-08 10:49:04.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GTMAppAuthFetcherAuthorization+Keychain.m[0m
+INFO [2022-09-08 10:49:04.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FastEasyMapping-Info.plist[0m
+INFO [2022-09-08 10:49:04.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSArray+FEMPropertyRepresentation.m[0m
+INFO [2022-09-08 10:49:04.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FastEasyMapping-dummy.m[0m
+INFO [2022-09-08 10:49:04.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMTypeIntrospection.m[0m
+INFO [2022-09-08 10:49:04.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GoogleDataTransport.h[0m
+INFO [2022-09-08 10:49:04.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GoogleDataTransport-umbrella.h[0m
+INFO [2022-09-08 10:49:04.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GDTCORTransport.h[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GDTCORTargets.h[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GDTCOREventTransformer.h[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GDTCOREventDataObject.h[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GDTCOREvent.h[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GDTCOREndpoints.h[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GDTCORConsoleLogger.h[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GDTCORClock.h[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m GoogleUtilities.framework (in target 'GoogleUtilities' from project 'Pods')[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GEOSwift-umbrella.h[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Copy XCFrameworks'[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseCoreInternal-umbrella.h[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m GoogleSignIn_GoogleSignIn.bundle (in target 'GoogleSignIn_GoogleSignIn' from project 'GoogleSignIn')[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m GoogleDataTransport-Info.plist[0m
+INFO [2022-09-08 10:49:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m client_metrics.nanopb.c[0m
+INFO [2022-09-08 10:49:04.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m cct.nanopb.c[0m
+INFO [2022-09-08 10:49:04.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GoogleDataTransport-dummy.m[0m
+INFO [2022-09-08 10:49:04.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORUploadCoordinator.m[0m
+INFO [2022-09-08 10:49:05.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GoogleDataTransport_vers.c[0m
+INFO [2022-09-08 10:49:05.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORUploadBatch.m[0m
+INFO [2022-09-08 10:49:05.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORTransport.m[0m
+INFO [2022-09-08 10:49:05.40]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m MapboxCoreNavigation.framework (in target 'MapboxCoreNavigation' from project 'Pods')[0m
+INFO [2022-09-08 10:49:05.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LazyImage.swift[0m
+INFO [2022-09-08 10:49:05.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m VideoPlayerView.swift[0m
+INFO [2022-09-08 10:49:05.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageView.swift[0m
+INFO [2022-09-08 10:49:05.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Internal.swift[0m
+INFO [2022-09-08 10:49:05.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Image.swift[0m
+INFO [2022-09-08 10:49:05.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LazyImageView.swift[0m
+INFO [2022-09-08 10:49:05.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:05.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Navigation.storyboard[0m
+INFO [2022-09-08 10:49:05.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORTransformer.m[0m
+INFO [2022-09-08 10:49:05.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORStorageMetadata.m[0m
+INFO [2022-09-08 10:49:05.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORStorageEventSelector.m[0m
+INFO [2022-09-08 10:49:05.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORRegistrar.m[0m
+INFO [2022-09-08 10:49:05.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORReachability.m[0m
+INFO [2022-09-08 10:49:05.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORPlatform.m[0m
+INFO [2022-09-08 10:49:05.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORMetricsMetadata.m[0m
+INFO [2022-09-08 10:49:05.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORMetricsController.m[0m
+INFO [2022-09-08 10:49:05.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORMetrics.m[0m
+INFO [2022-09-08 10:49:05.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORMetrics+GDTCCTSupport.m[0m
+INFO [2022-09-08 10:49:05.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m MapboxNavigation[0m
+INFO [2022-09-08 10:49:06.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORLogSourceMetrics.m[0m
+INFO [2022-09-08 10:49:06.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m MapboxNavigation-Info.plist[0m
+INFO [2022-09-08 10:49:06.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORLifecycle.m[0m
+INFO [2022-09-08 10:49:06.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORFlatFileStorage.m[0m
+INFO [2022-09-08 10:49:06.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORFlatFileStorage+Promises.m[0m
+INFO [2022-09-08 10:49:06.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCOREvent.m[0m
+INFO [2022-09-08 10:49:06.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCOREvent+GDTMetricsSupport.m[0m
+INFO [2022-09-08 10:49:06.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCOREvent+GDTCCTSupport.m[0m
+INFO [2022-09-08 10:49:06.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCOREndpoints.m[0m
+INFO [2022-09-08 10:49:06.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORDirectorySizeTracker.m[0m
+INFO [2022-09-08 10:49:06.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORConsoleLogger.m[0m
+INFO [2022-09-08 10:49:06.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORClock.m[0m
+INFO [2022-09-08 10:49:06.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCORAssert.m[0m
+INFO [2022-09-08 10:49:06.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCCTUploader.m[0m
+INFO [2022-09-08 10:49:06.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCCTUploadOperation.m[0m
+INFO [2022-09-08 10:49:06.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCCTNanopbHelpers.m[0m
+INFO [2022-09-08 10:49:06.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GDTCCTCompressionHelper.m[0m
+INFO [2022-09-08 10:49:06.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array.swift[0m
+INFO [2022-09-08 10:49:06.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIImageView.swift[0m
+INFO [2022-09-08 10:49:06.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AnimatedFrame.swift[0m
+INFO [2022-09-08 10:49:06.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Animator.swift[0m
+INFO [2022-09-08 10:49:06.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageSourceHelpers.swift[0m
+INFO [2022-09-08 10:49:06.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FrameStore.swift[0m
+INFO [2022-09-08 10:49:06.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIFAnimatable.swift[0m
+INFO [2022-09-08 10:49:06.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIImage.swift[0m
+INFO [2022-09-08 10:49:06.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CGSize.swift[0m
+INFO [2022-09-08 10:49:06.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GIFImageView.swift[0m
+INFO [2022-09-08 10:49:06.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m GEOSwift-Info.plist[0m
+INFO [2022-09-08 10:49:06.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FirebaseCoreInternal-Info.plist[0m
+INFO [2022-09-08 10:49:06.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FastEasyMapping_vers.c[0m
+INFO [2022-09-08 10:49:06.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMSerializer.m[0m
+INFO [2022-09-08 10:49:06.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m GoogleDataTransport[0m
+INFO [2022-09-08 10:49:06.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMRepresentationUtility.m[0m
+INFO [2022-09-08 10:49:06.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMRelationshipAssignmentContext.m[0m
+INFO [2022-09-08 10:49:06.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMRelationship.m[0m
+INFO [2022-09-08 10:49:06.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseCoreDiagnostics-umbrella.h[0m
+INFO [2022-09-08 10:49:06.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRCoreDiagnostics.h[0m
+INFO [2022-09-08 10:49:06.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMObjectStore.m[0m
+INFO [2022-09-08 10:49:07.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Storage.swift[0m
+INFO [2022-09-08 10:49:07.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Heartbeat.swift[0m
+INFO [2022-09-08 10:49:07.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HeartbeatController.swift[0m
+INFO [2022-09-08 10:49:07.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WeakContainer.swift[0m
+INFO [2022-09-08 10:49:07.19]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m MapboxNavigation.framework (in target 'MapboxNavigation' from project 'Pods')[0m
+INFO [2022-09-08 10:49:07.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HeartbeatsBundle.swift[0m
+INFO [2022-09-08 10:49:07.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HeartbeatsPayload.swift[0m
+INFO [2022-09-08 10:49:07.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HeartbeatStorage.swift[0m
+INFO [2022-09-08 10:49:07.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StorageFactory.swift[0m
+INFO [2022-09-08 10:49:07.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RingBuffer.swift[0m
+INFO [2022-09-08 10:49:07.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Gifu.o[0m
+INFO [2022-09-08 10:49:07.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Boundable.swift[0m
+INFO [2022-09-08 10:49:07.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Circle.swift[0m
+INFO [2022-09-08 10:49:07.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ClosednessTestable.swift[0m
+INFO [2022-09-08 10:49:07.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CodableGeometry.swift[0m
+INFO [2022-09-08 10:49:07.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Envelope.swift[0m
+INFO [2022-09-08 10:49:07.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Feature.swift[0m
+INFO [2022-09-08 10:49:07.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Feature+Codable.swift[0m
+INFO [2022-09-08 10:49:07.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GEOSError.swift[0m
+INFO [2022-09-08 10:49:07.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GEOSHelpers.swift[0m
+INFO [2022-09-08 10:49:07.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GEOSObject.swift[0m
+INFO [2022-09-08 10:49:07.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GEOSwiftError.swift[0m
+INFO [2022-09-08 10:49:07.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m JSON.swift[0m
+INFO [2022-09-08 10:49:07.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m JSON+Codable.swift[0m
+INFO [2022-09-08 10:49:08.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineString.swift[0m
+INFO [2022-09-08 10:49:08.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polygon+GEOS.swift[0m
+INFO [2022-09-08 10:49:08.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimplicityTestable.swift[0m
+INFO [2022-09-08 10:49:08.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WKBConvertible.swift[0m
+INFO [2022-09-08 10:49:08.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WKBInitializable.swift[0m
+INFO [2022-09-08 10:49:08.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WKTConvertible.swift[0m
+INFO [2022-09-08 10:49:08.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WKTInitializable.swift[0m
+INFO [2022-09-08 10:49:08.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiPolygon+GEOS.swift[0m
+INFO [2022-09-08 10:49:08.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Point.swift[0m
+INFO [2022-09-08 10:49:08.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Point+Codable.swift[0m
+INFO [2022-09-08 10:49:08.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Point+GEOS.swift[0m
+INFO [2022-09-08 10:49:08.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polygon.swift[0m
+INFO [2022-09-08 10:49:08.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Polygon+Codable.swift[0m
+INFO [2022-09-08 10:49:08.11]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m GoogleDataTransport.framework (in target 'GoogleDataTransport' from project 'Pods')[0m
+INFO [2022-09-08 10:49:08.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Geometry+GEOS.swift[0m
+INFO [2022-09-08 10:49:08.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryCollection.swift[0m
+INFO [2022-09-08 10:49:08.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryCollection+Codable.swift[0m
+INFO [2022-09-08 10:49:08.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryCollection+GEOS.swift[0m
+INFO [2022-09-08 10:49:08.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryConvertible.swift[0m
+INFO [2022-09-08 10:49:08.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeometryConvertible+GEOS.swift[0m
+INFO [2022-09-08 10:49:08.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GEOSContext.swift[0m
+INFO [2022-09-08 10:49:08.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiLineString+GEOS.swift[0m
+INFO [2022-09-08 10:49:08.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiPoint.swift[0m
+INFO [2022-09-08 10:49:08.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiPoint+Codable.swift[0m
+INFO [2022-09-08 10:49:08.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiPoint+GEOS.swift[0m
+INFO [2022-09-08 10:49:08.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiPolygon.swift[0m
+INFO [2022-09-08 10:49:08.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiPolygon+Codable.swift[0m
+INFO [2022-09-08 10:49:08.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m NukeUI.o[0m
+INFO [2022-09-08 10:49:08.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineString+Codable.swift[0m
+INFO [2022-09-08 10:49:08.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineString+GEOS.swift[0m
+INFO [2022-09-08 10:49:08.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineStringConvertible.swift[0m
+INFO [2022-09-08 10:49:08.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineStringConvertible+GEOS.swift[0m
+INFO [2022-09-08 10:49:08.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiLineString.swift[0m
+INFO [2022-09-08 10:49:08.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultiLineString+Codable.swift[0m
+INFO [2022-09-08 10:49:08.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GEOSwift_vers.c[0m
+INFO [2022-09-08 10:49:08.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GEOSwift-dummy.m[0m
+INFO [2022-09-08 10:49:08.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FeatureCollection.swift[0m
+INFO [2022-09-08 10:49:08.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FeatureCollection+Codable.swift[0m
+INFO [2022-09-08 10:49:08.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSON.swift[0m
+INFO [2022-09-08 10:49:08.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSON+Codable.swift[0m
+INFO [2022-09-08 10:49:08.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSONType.swift[0m
+INFO [2022-09-08 10:49:08.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Geometry.swift[0m
+INFO [2022-09-08 10:49:08.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Geometry+Codable.swift[0m
+INFO [2022-09-08 10:49:08.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseCoreInternal_vers.c[0m
+INFO [2022-09-08 10:49:08.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseCoreInternal-dummy.m[0m
+INFO [2022-09-08 10:49:08.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m _ObjC_HeartbeatController.swift[0m
+INFO [2022-09-08 10:49:08.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m _ObjC_HeartbeatsPayload.swift[0m
+INFO [2022-09-08 10:49:08.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FirebaseCoreDiagnostics-Info.plist[0m
+INFO [2022-09-08 10:49:08.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m firebasecore.nanopb.c[0m
+INFO [2022-09-08 10:49:08.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseCoreDiagnostics_vers.c[0m
+INFO [2022-09-08 10:49:08.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseCoreDiagnostics-dummy.m[0m
+INFO [2022-09-08 10:49:09.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCoreDiagnostics.m[0m
+INFO [2022-09-08 10:49:12.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMObjectRef.m[0m
+INFO [2022-09-08 10:49:12.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMObjectCache.m[0m
+INFO [2022-09-08 10:49:12.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMMergeableCollection.m[0m
+INFO [2022-09-08 10:49:12.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMMapping.m[0m
+INFO [2022-09-08 10:49:12.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMManagedObjectStore.m[0m
+INFO [2022-09-08 10:49:12.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseCore.h[0m
+INFO [2022-09-08 10:49:12.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseCore-umbrella.h[0m
+INFO [2022-09-08 10:49:12.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRVersion.h[0m
+INFO [2022-09-08 10:49:12.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIROptions.h[0m
+INFO [2022-09-08 10:49:12.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRLoggerLevel.h[0m
+INFO [2022-09-08 10:49:12.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRConfiguration.h[0m
+INFO [2022-09-08 10:49:12.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRApp.h[0m
+INFO [2022-09-08 10:49:12.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMExcludableCollection.m[0m
+INFO [2022-09-08 10:49:12.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FirebaseCoreInternal[0m
+INFO [2022-09-08 10:49:12.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseInstallations.h[0m
+INFO [2022-09-08 10:49:12.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseInstallations-umbrella.h[0m
+INFO [2022-09-08 10:49:12.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRInstallationsErrors.h[0m
+INFO [2022-09-08 10:49:12.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRInstallationsAuthTokenResult.h[0m
+INFO [2022-09-08 10:49:12.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRInstallations.h[0m
+INFO [2022-09-08 10:49:12.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseDynamicLinks.h[0m
+INFO [2022-09-08 10:49:12.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseDynamicLinks-umbrella.h[0m
+INFO [2022-09-08 10:49:12.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRDynamicLinksCommon.h[0m
+INFO [2022-09-08 10:49:12.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRDynamicLinks.h[0m
+INFO [2022-09-08 10:49:12.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRDynamicLink.h[0m
+INFO [2022-09-08 10:49:12.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FDLURLComponents.h[0m
+INFO [2022-09-08 10:49:12.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseInstallations_vers.c[0m
+INFO [2022-09-08 10:49:12.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseInstallations-dummy.m[0m
+INFO [2022-09-08 10:49:12.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsStoredItem.m[0m
+INFO [2022-09-08 10:49:12.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsStoredAuthToken.m[0m
+INFO [2022-09-08 10:49:12.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m GEOSwift[0m
+INFO [2022-09-08 10:49:12.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseMessaging.h[0m
+INFO [2022-09-08 10:49:12.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseMessaging-umbrella.h[0m
+INFO [2022-09-08 10:49:12.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRMessagingExtensionHelper.h[0m
+INFO [2022-09-08 10:49:12.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRMessaging.h[0m
+INFO [2022-09-08 10:49:12.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsStore.m[0m
+INFO [2022-09-08 10:49:12.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsSingleOperationPromiseCache.m[0m
+INFO [2022-09-08 10:49:12.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsLogger.m[0m
+INFO [2022-09-08 10:49:12.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m me.nanopb.c[0m
+INFO [2022-09-08 10:49:12.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSError+FIRMessaging.m[0m
+INFO [2022-09-08 10:49:12.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSDictionary+FIRMessaging.m[0m
+INFO [2022-09-08 10:49:12.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseMessaging_vers.c[0m
+INFO [2022-09-08 10:49:12.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseMessaging-dummy.m[0m
+INFO [2022-09-08 10:49:12.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingUtilities.m[0m
+INFO [2022-09-08 10:49:12.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingTopicOperation.m[0m
+INFO [2022-09-08 10:49:12.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingTokenStore.m[0m
+INFO [2022-09-08 10:49:12.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingTokenOperation.m[0m
+INFO [2022-09-08 10:49:12.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingTokenManager.m[0m
+INFO [2022-09-08 10:49:12.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingTokenInfo.m[0m
+INFO [2022-09-08 10:49:12.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingTokenFetchOperation.m[0m
+INFO [2022-09-08 10:49:12.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingTokenDeleteOperation.m[0m
+INFO [2022-09-08 10:49:12.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingSyncMessageManager.m[0m
+INFO [2022-09-08 10:49:12.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingRmqManager.m[0m
+INFO [2022-09-08 10:49:12.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingRemoteNotificationsProxy.m[0m
+INFO [2022-09-08 10:49:12.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingPubSub.m[0m
+INFO [2022-09-08 10:49:12.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingPersistentSyncMessage.m[0m
+INFO [2022-09-08 10:49:12.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingPendingTopicsList.m[0m
+INFO [2022-09-08 10:49:12.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingLogger.m[0m
+INFO [2022-09-08 10:49:12.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingKeychain.m[0m
+INFO [2022-09-08 10:49:12.51]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m GEOSwift.framework (in target 'GEOSwift' from project 'Pods')[0m
+INFO [2022-09-08 10:49:12.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingExtensionHelper.m[0m
+INFO [2022-09-08 10:49:12.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingContextManagerService.m[0m
+INFO [2022-09-08 10:49:12.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingConstants.m[0m
+INFO [2022-09-08 10:49:12.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingCheckinStore.m[0m
+INFO [2022-09-08 10:49:12.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingCheckinService.m[0m
+INFO [2022-09-08 10:49:12.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingCheckinPreferences.m[0m
+INFO [2022-09-08 10:49:12.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingBackupExcludedPlist.m[0m
+INFO [2022-09-08 10:49:12.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingAuthService.m[0m
+INFO [2022-09-08 10:49:12.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingAuthKeychain.m[0m
+INFO [2022-09-08 10:49:12.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FirebaseCoreDiagnostics[0m
+INFO [2022-09-08 10:49:12.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingAnalytics.m[0m
+INFO [2022-09-08 10:49:12.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessagingAPNSInfo.m[0m
+INFO [2022-09-08 10:49:12.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRMessaging.m[0m
+INFO [2022-09-08 10:49:12.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsItem.m[0m
+INFO [2022-09-08 10:49:12.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsItem+RegisterInstallationAPI.m[0m
+INFO [2022-09-08 10:49:12.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsIIDTokenStore.m[0m
+INFO [2022-09-08 10:49:12.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsIIDStore.m[0m
+INFO [2022-09-08 10:49:12.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsIDController.m[0m
+INFO [2022-09-08 10:49:12.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsHTTPError.m[0m
+INFO [2022-09-08 10:49:12.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsErrorUtil.m[0m
+INFO [2022-09-08 10:49:12.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsBackoffController.m[0m
+INFO [2022-09-08 10:49:12.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsAuthTokenResult.m[0m
+INFO [2022-09-08 10:49:12.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallationsAPIService.m[0m
+INFO [2022-09-08 10:49:12.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInstallations.m[0m
+INFO [2022-09-08 10:49:12.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCurrentDateProvider.m[0m
+INFO [2022-09-08 10:49:12.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GINInvocation.m[0m
+INFO [2022-09-08 10:49:13.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GINArgument.m[0m
+INFO [2022-09-08 10:49:13.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseDynamicLinks_vers.c[0m
+INFO [2022-09-08 10:49:13.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseDynamicLinks-dummy.m[0m
+INFO [2022-09-08 10:49:14.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDynamicLinks.m[0m
+INFO [2022-09-08 10:49:16.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDynamicLinkNetworking.m[0m
+INFO [2022-09-08 10:49:16.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDynamicLinkComponentsKeyProvider.m[0m
+INFO [2022-09-08 10:49:16.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDynamicLink.m[0m
+INFO [2022-09-08 10:49:16.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDLScionLogging.m[0m
+INFO [2022-09-08 10:49:16.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDLRetrievalProcessResult.m[0m
+INFO [2022-09-08 10:49:16.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDLRetrievalProcessFactory.m[0m
+INFO [2022-09-08 10:49:16.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDLJavaScriptExecutor.m[0m
+INFO [2022-09-08 10:49:16.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDLDefaultRetrievalProcessV2.m[0m
+INFO [2022-09-08 10:49:16.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FDLUtilities.m[0m
+INFO [2022-09-08 10:49:16.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FDLURLComponents.m[0m
+INFO [2022-09-08 10:49:16.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FDLLogging.m[0m
+INFO [2022-09-08 10:49:16.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FDLDeviceHeuristicsHelper.m[0m
+INFO [2022-09-08 10:49:16.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseCore_vers.c[0m
+INFO [2022-09-08 10:49:16.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseCore-dummy.m[0m
+INFO [2022-09-08 10:49:16.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseCrashlytics.h[0m
+INFO [2022-09-08 10:49:16.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseCrashlytics-umbrella.h[0m
+INFO [2022-09-08 10:49:16.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRStackFrame.h[0m
+INFO [2022-09-08 10:49:16.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRExceptionModel.h[0m
+INFO [2022-09-08 10:49:16.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRCrashlyticsReport.h[0m
+INFO [2022-09-08 10:49:16.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRCrashlytics.h[0m
+INFO [2022-09-08 10:49:16.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m crashlytics.nanopb.c[0m
+INFO [2022-09-08 10:49:16.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseCrashlytics_vers.c[0m
+INFO [2022-09-08 10:49:16.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseCrashlytics-dummy.m[0m
+INFO [2022-09-08 10:49:16.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRStackFrame.m[0m
+INFO [2022-09-08 10:49:16.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRExceptionModel.m[0m
+INFO [2022-09-08 10:49:16.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCrashlyticsReport.m[0m
+INFO [2022-09-08 10:49:16.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCrashlytics.m[0m
+INFO [2022-09-08 10:49:18.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSdSYM.m[0m
+INFO [2022-09-08 10:49:18.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSUtility.m[0m
+INFO [2022-09-08 10:49:18.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSUserLogging.m[0m
+INFO [2022-09-08 10:49:18.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSUserDefaults.m[0m
+INFO [2022-09-08 10:49:18.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSUnwind_x86.c[0m
+INFO [2022-09-08 10:49:18.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSUnwind_arm.c[0m
+INFO [2022-09-08 10:49:18.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSUnwind.c[0m
+INFO [2022-09-08 10:49:18.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSUUID.m[0m
+INFO [2022-09-08 10:49:18.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSURLBuilder.m[0m
+INFO [2022-09-08 10:49:18.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSThreadState.c[0m
+INFO [2022-09-08 10:49:18.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSThreadArrayOperation.m[0m
+INFO [2022-09-08 10:49:18.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSSymbolicationOperation.m[0m
+INFO [2022-09-08 10:49:18.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSSymbolResolver.m[0m
+INFO [2022-09-08 10:49:18.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSSignal.c[0m
+INFO [2022-09-08 10:49:18.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSSettingsManager.m[0m
+INFO [2022-09-08 10:49:18.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSSettings.m[0m
+INFO [2022-09-08 10:49:18.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSSerializeSymbolicatedFramesOperation.m[0m
+INFO [2022-09-08 10:49:18.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSReportUploader.m[0m
+INFO [2022-09-08 10:49:18.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSReportManager.m[0m
+INFO [2022-09-08 10:49:18.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSReportAdapter.m[0m
+INFO [2022-09-08 10:49:18.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSRecordIdentity.m[0m
+INFO [2022-09-08 10:49:18.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSRecordHost.m[0m
+INFO [2022-09-08 10:49:18.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSRecordBase.m[0m
+INFO [2022-09-08 10:49:18.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSRecordApplication.m[0m
+INFO [2022-09-08 10:49:18.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSProfiling.c[0m
+INFO [2022-09-08 10:49:18.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSProcessReportOperation.m[0m
+INFO [2022-09-08 10:49:18.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSProcess.c[0m
+INFO [2022-09-08 10:49:18.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSOnDemandModel.m[0m
+INFO [2022-09-08 10:49:18.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSNotificationManager.m[0m
+INFO [2022-09-08 10:49:18.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSNetworkResponseHandler.m[0m
+INFO [2022-09-08 10:49:18.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSNetworkOperation.m[0m
+INFO [2022-09-08 10:49:18.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSMultipartMimeStreamEncoder.m[0m
+INFO [2022-09-08 10:49:18.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSMetricKitManager.m[0m
+INFO [2022-09-08 10:49:18.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSManagerData.m[0m
+INFO [2022-09-08 10:49:18.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSMachOSlice.m[0m
+INFO [2022-09-08 10:49:18.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSMachOBinary.m[0m
+INFO [2022-09-08 10:49:18.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSMachO.m[0m
+INFO [2022-09-08 10:49:18.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSMachException.c[0m
+INFO [2022-09-08 10:49:18.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSLogger.m[0m
+INFO [2022-09-08 10:49:18.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSLaunchMarkerModel.m[0m
+INFO [2022-09-08 10:49:18.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSInternalReport.m[0m
+INFO [2022-09-08 10:49:18.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSInternalLogging.c[0m
+INFO [2022-09-08 10:49:18.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSInstallIdentifierModel.m[0m
+INFO [2022-09-08 10:49:18.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSHost.m[0m
+INFO [2022-09-08 10:49:18.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSHandler.m[0m
+INFO [2022-09-08 10:49:18.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSFileManager.m[0m
+INFO [2022-09-08 10:49:18.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSFile.m[0m
+INFO [2022-09-08 10:49:18.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSFABNetworkClient.m[0m
+INFO [2022-09-08 10:49:18.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSFABHost.m[0m
+INFO [2022-09-08 10:49:18.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSFABAsyncOperation.m[0m
+INFO [2022-09-08 10:49:18.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSExistingReportManager.m[0m
+INFO [2022-09-08 10:49:19.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSExecutionIdentifierModel.m[0m
+INFO [2022-09-08 10:49:19.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSException.mm[0m
+INFO [2022-09-08 10:49:19.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSDwarfUnwind.c[0m
+INFO [2022-09-08 10:49:19.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSDwarfExpressionMachine.c[0m
+INFO [2022-09-08 10:49:19.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSDownloadAndSaveSettingsOperation.m[0m
+INFO [2022-09-08 10:49:19.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSDemangleOperation.mm[0m
+INFO [2022-09-08 10:49:19.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSDataParsing.c[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSDataCollectionToken.m[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSDataCollectionArbiter.m[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSCrashedMarkerFile.c[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSContext.m[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSConstants.m[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSCompoundOperation.m[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSCompactUnwind.c[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSCodeMapping.m[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSCallStackTree.m[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSByteUtility.m[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSBinaryImage.m[0m
+INFO [2022-09-08 10:49:19.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSAsyncOperation.m[0m
+INFO [2022-09-08 10:49:19.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSApplicationIdentifierModel.m[0m
+INFO [2022-09-08 10:49:19.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSApplication.m[0m
+INFO [2022-09-08 10:49:19.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSAnalyticsManager.m[0m
+INFO [2022-09-08 10:49:19.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCLSAllocate.c[0m
+INFO [2022-09-08 10:49:19.92]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FirebaseCoreDiagnostics.framework (in target 'FirebaseCoreDiagnostics' from project 'Pods')[0m
+INFO [2022-09-08 10:49:19.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRVersion.m[0m
+INFO [2022-09-08 10:49:19.92]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FirebaseCoreInternal.framework (in target 'FirebaseCoreInternal' from project 'Pods')[0m
+INFO [2022-09-08 10:49:19.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIROptions.m[0m
+INFO [2022-09-08 10:49:19.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRLogger.m[0m
+INFO [2022-09-08 10:49:21.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRHeartbeatLogger.m[0m
+INFO [2022-09-08 10:49:21.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRHeartbeatInfo.m[0m
+INFO [2022-09-08 10:49:21.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FirebaseCore-Info.plist[0m
+INFO [2022-09-08 10:49:21.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRFirebaseUserAgent.m[0m
+INFO [2022-09-08 10:49:21.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDiagnosticsData.m[0m
+INFO [2022-09-08 10:49:21.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRDependency.m[0m
+INFO [2022-09-08 10:49:21.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCoreDiagnosticsConnector.m[0m
+INFO [2022-09-08 10:49:21.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRConfiguration.m[0m
+INFO [2022-09-08 10:49:21.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRComponentType.m[0m
+INFO [2022-09-08 10:49:21.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRComponentContainer.m[0m
+INFO [2022-09-08 10:49:21.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRComponent.m[0m
+INFO [2022-09-08 10:49:21.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRBundleUtil.m[0m
+INFO [2022-09-08 10:49:21.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRApp.m[0m
+INFO [2022-09-08 10:49:21.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRAnalyticsConfiguration.m[0m
+INFO [2022-09-08 10:49:21.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMDeserializer.m[0m
+INFO [2022-09-08 10:49:21.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMAttribute.m[0m
+INFO [2022-09-08 10:49:21.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FEMAssignmentPolicy.m[0m
+INFO [2022-09-08 10:49:21.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseABTesting.h[0m
+INFO [2022-09-08 10:49:21.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseABTesting-umbrella.h[0m
+INFO [2022-09-08 10:49:21.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRLifecycleEvents.h[0m
+INFO [2022-09-08 10:49:21.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRExperimentController.h[0m
+INFO [2022-09-08 10:49:21.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m parser.c[0m
+INFO [2022-09-08 10:49:21.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FastEasyMapping[0m
+INFO [2022-09-08 10:49:21.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseABTesting-dummy.m[0m
+INFO [2022-09-08 10:49:21.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseRemoteConfig.h[0m
+INFO [2022-09-08 10:49:21.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseRemoteConfig-umbrella.h[0m
+INFO [2022-09-08 10:49:21.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRRemoteConfig.h[0m
+INFO [2022-09-08 10:49:21.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RCNUserDefaultsManager.m[0m
+INFO [2022-09-08 10:49:21.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RCNPersonalization.m[0m
+INFO [2022-09-08 10:49:21.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RCNDevice.m[0m
+INFO [2022-09-08 10:49:21.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RCNConstants3P.m[0m
+INFO [2022-09-08 10:49:21.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RCNConfigSettings.m[0m
+INFO [2022-09-08 10:49:21.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RCNConfigFetch.m[0m
+INFO [2022-09-08 10:49:21.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RCNConfigExperiment.m[0m
+INFO [2022-09-08 10:49:21.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RCNConfigDBManager.m[0m
+INFO [2022-09-08 10:49:21.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RCNConfigContent.m[0m
+INFO [2022-09-08 10:49:21.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseRemoteConfig_vers.c[0m
+INFO [2022-09-08 10:49:21.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseRemoteConfig-dummy.m[0m
+INFO [2022-09-08 10:49:21.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRRemoteConfigComponent.m[0m
+INFO [2022-09-08 10:49:21.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRRemoteConfig.m[0m
+INFO [2022-09-08 10:49:21.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRConfigValue.m[0m
+INFO [2022-09-08 10:49:21.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseABTesting_vers.c[0m
+INFO [2022-09-08 10:49:21.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRLifecycleEvents.m[0m
+INFO [2022-09-08 10:49:21.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRExperimentController.m[0m
+INFO [2022-09-08 10:49:21.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ABTExperimentPayload.m[0m
+INFO [2022-09-08 10:49:21.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ABTConditionalUserPropertyController.m[0m
+INFO [2022-09-08 10:49:21.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseInAppMessaging.h[0m
+INFO [2022-09-08 10:49:21.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FirebaseInAppMessaging-umbrella.h[0m
+INFO [2022-09-08 10:49:21.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRInAppMessagingRendering.h[0m
+INFO [2022-09-08 10:49:21.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m FIRInAppMessaging.h[0m
+INFO [2022-09-08 10:49:21.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXRoot.swift[0m
+INFO [2022-09-08 10:49:22.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXRoute.swift[0m
+INFO [2022-09-08 10:49:22.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXRoutePoint.swift[0m
+INFO [2022-09-08 10:49:22.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXRouteProtocol.swift[0m
+INFO [2022-09-08 10:49:22.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXTrack.swift[0m
+INFO [2022-09-08 10:49:22.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXTrackPoint.swift[0m
+INFO [2022-09-08 10:49:22.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXTrackSegment.swift[0m
+INFO [2022-09-08 10:49:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m fiam.nanopb.c[0m
+INFO [2022-09-08 10:49:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIColor+FIRIAMHexString.m[0m
+INFO [2022-09-08 10:49:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSString+FIRInterlaceStrings.m[0m
+INFO [2022-09-08 10:49:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseInAppMessaging_vers.c[0m
+INFO [2022-09-08 10:49:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirebaseInAppMessaging-dummy.m[0m
+INFO [2022-09-08 10:49:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInAppMessagingRenderingDataClasses.m[0m
+INFO [2022-09-08 10:49:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInAppMessaging.m[0m
+INFO [2022-09-08 10:49:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FirebaseCore[0m
+INFO [2022-09-08 10:49:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInAppMessaging+Bootstrap.m[0m
+INFO [2022-09-08 10:49:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMTimeFetcher.m[0m
+INFO [2022-09-08 10:49:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMServerMsgFetchStorage.m[0m
+INFO [2022-09-08 10:49:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMSDKSettings.m[0m
+INFO [2022-09-08 10:49:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMSDKModeManager.m[0m
+INFO [2022-09-08 10:49:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMRuntimeManager.m[0m
+INFO [2022-09-08 10:49:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMRenderingWindowHelper.m[0m
+INFO [2022-09-08 10:49:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMRenderingEffectSetting.m[0m
+INFO [2022-09-08 10:49:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMMsgFetcherUsingRestful.m[0m
+INFO [2022-09-08 10:49:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMModalViewController.m[0m
+INFO [2022-09-08 10:49:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMMessageDefinition.m[0m
+INFO [2022-09-08 10:49:22.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMMessageContentDataWithImageURL.m[0m
+INFO [2022-09-08 10:49:22.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMMessageClientCache.m[0m
+INFO [2022-09-08 10:49:22.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMImageOnlyViewController.m[0m
+INFO [2022-09-08 10:49:22.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMFetchResponseParser.m[0m
+INFO [2022-09-08 10:49:22.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMFetchOnAppForegroundFlow.m[0m
+INFO [2022-09-08 10:49:22.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMFetchFlow.m[0m
+INFO [2022-09-08 10:49:22.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMElapsedTimeTracker.m[0m
+INFO [2022-09-08 10:49:22.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMDisplayTriggerDefinition.m[0m
+INFO [2022-09-08 10:49:22.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMDisplayExecutor.m[0m
+INFO [2022-09-08 10:49:23.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMDisplayCheckTriggerFlow.m[0m
+INFO [2022-09-08 10:49:23.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMDisplayCheckOnFetchDoneNotificationFlow.m[0m
+INFO [2022-09-08 10:49:23.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMDisplayCheckOnAppForegroundFlow.m[0m
+INFO [2022-09-08 10:49:23.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMDisplayCheckOnAnalyticEventsFlow.m[0m
+INFO [2022-09-08 10:49:23.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMDefaultDisplayImpl.m[0m
+INFO [2022-09-08 10:49:23.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMClientInfoFetcher.m[0m
+INFO [2022-09-08 10:49:23.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMClearcutUploader.m[0m
+INFO [2022-09-08 10:49:23.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMClearcutLogger.m[0m
+INFO [2022-09-08 10:49:23.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMClearcutLogStorage.m[0m
+INFO [2022-09-08 10:49:23.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMClearcutHttpRequestSender.m[0m
+INFO [2022-09-08 10:49:23.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMCardViewController.m[0m
+INFO [2022-09-08 10:49:23.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMBookKeeper.m[0m
+INFO [2022-09-08 10:49:23.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMBaseRenderingViewController.m[0m
+INFO [2022-09-08 10:49:23.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMBannerViewUIWindow.m[0m
+INFO [2022-09-08 10:49:23.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMBannerViewController.m[0m
+INFO [2022-09-08 10:49:23.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMAnalyticsEventLoggerImpl.m[0m
+INFO [2022-09-08 10:49:23.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMActivityLogger.m[0m
+INFO [2022-09-08 10:49:23.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRIAMActionURLFollower.m[0m
+INFO [2022-09-08 10:49:23.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCore+InAppMessagingDisplay.m[0m
+INFO [2022-09-08 10:49:23.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRCore+InAppMessaging.m[0m
+INFO [2022-09-08 10:49:23.27]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FastEasyMapping.framework (in target 'FastEasyMapping' from project 'Pods')[0m
+INFO [2022-09-08 10:49:23.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXCompression.swift[0m
+INFO [2022-09-08 10:49:23.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXCopyright.swift[0m
+INFO [2022-09-08 10:49:23.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXElement.swift[0m
+INFO [2022-09-08 10:49:23.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXEmail.swift[0m
+INFO [2022-09-08 10:49:23.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXError.swift[0m
+INFO [2022-09-08 10:49:23.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXExtensions.swift[0m
+INFO [2022-09-08 10:49:23.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXExtensionsElement.swift[0m
+INFO [2022-09-08 10:49:23.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXFix.swift[0m
+INFO [2022-09-08 10:49:24.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXPerson.swift[0m
+INFO [2022-09-08 10:49:24.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXPoint.swift[0m
+INFO [2022-09-08 10:49:24.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXPointSegment.swift[0m
+INFO [2022-09-08 10:49:24.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXRawElement.swift[0m
+INFO [2022-09-08 10:49:24.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXWaypoint.swift[0m
+INFO [2022-09-08 10:49:24.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXWaypointProtocol.swift[0m
+INFO [2022-09-08 10:49:24.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSMutableString+XML.swift[0m
+INFO [2022-09-08 10:49:24.02]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FirebaseCore.framework (in target 'FirebaseCore' from project 'Pods')[0m
+INFO [2022-09-08 10:49:24.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Converters.swift[0m
+INFO [2022-09-08 10:49:24.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DateTimeParsers.swift[0m
+INFO [2022-09-08 10:49:24.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXAuthor.swift[0m
+INFO [2022-09-08 10:49:24.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXBounds.swift[0m
+INFO [2022-09-08 10:49:24.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXLegacy.swift[0m
+INFO [2022-09-08 10:49:24.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXLink.swift[0m
+INFO [2022-09-08 10:49:24.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXMetadata.swift[0m
+INFO [2022-09-08 10:49:24.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GPXParser.swift[0m
+INFO [2022-09-08 10:49:24.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m emitter.c[0m
+INFO [2022-09-08 10:49:24.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FirebaseInstallations[0m
+INFO [2022-09-08 10:49:24.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FirebaseDynamicLinks[0m
+INFO [2022-09-08 10:49:24.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FirebaseABTesting[0m
+INFO [2022-09-08 10:49:24.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FirebaseInstallations-Info.plist[0m
+INFO [2022-09-08 10:49:24.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FirebaseDynamicLinks-Info.plist[0m
+INFO [2022-09-08 10:49:24.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FirebaseABTesting-Info.plist[0m
+INFO [2022-09-08 10:49:24.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m api.c[0m
+INFO [2022-09-08 10:49:24.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDURLSessionProvider.m[0m
+INFO [2022-09-08 10:49:24.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDURLQueryComponent.m[0m
+INFO [2022-09-08 10:49:24.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m CYaml.o[0m
+INFO [2022-09-08 10:49:25.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Ride.swift[0m
+INFO [2022-09-08 10:49:25.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDTokenUtilities.m[0m
+INFO [2022-09-08 10:49:25.99]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FirebaseInstallations.framework (in target 'FirebaseInstallations' from project 'Pods')[0m
+INFO [2022-09-08 10:49:25.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Ride.swift[0m
+INFO [2022-09-08 10:49:26.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FirebaseMessaging[0m
+INFO [2022-09-08 10:49:26.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FirebaseCrashlytics[0m
+INFO [2022-09-08 10:49:26.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Copy XCFrameworks'[0m
+INFO [2022-09-08 10:49:26.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FirebaseMessaging-Info.plist[0m
+INFO [2022-09-08 10:49:26.01]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FirebaseDynamicLinks.framework (in target 'FirebaseDynamicLinks' from project 'Pods')[0m
+INFO [2022-09-08 10:49:26.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FirebaseCrashlytics-Info.plist[0m
+INFO [2022-09-08 10:49:26.01]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FirebaseABTesting.framework (in target 'FirebaseABTesting' from project 'Pods')[0m
+INFO [2022-09-08 10:49:26.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FirebaseRemoteConfig[0m
+INFO [2022-09-08 10:49:26.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Yams.o[0m
+INFO [2022-09-08 10:49:26.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FirebaseRemoteConfig-Info.plist[0m
+INFO [2022-09-08 10:49:26.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FIRInAppMessageDisplayStoryboard.storyboard[0m
+INFO [2022-09-08 10:49:26.02]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FirebaseMessaging.framework (in target 'FirebaseMessaging' from project 'Pods')[0m
+INFO [2022-09-08 10:49:26.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Ride.swift[0m
+INFO [2022-09-08 10:49:26.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Ride.swift[0m
+INFO [2022-09-08 10:49:26.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m CoreGPX.o[0m
+INFO [2022-09-08 10:49:26.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m BikemapCore.o[0m
+INFO [2022-09-08 10:49:26.16]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FirebaseCrashlytics.framework (in target 'FirebaseCrashlytics' from project 'Pods')[0m
+INFO [2022-09-08 10:49:26.16]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FirebaseRemoteConfig.framework (in target 'FirebaseRemoteConfig' from project 'Pods')[0m
+INFO [2022-09-08 10:49:26.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDTokenResponse.m[0m
+INFO [2022-09-08 10:49:26.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDTokenRequest.m[0m
+INFO [2022-09-08 10:49:26.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDServiceDiscovery.m[0m
+INFO [2022-09-08 10:49:26.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDServiceConfiguration.m[0m
+INFO [2022-09-08 10:49:26.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDScopes.m[0m
+INFO [2022-09-08 10:49:26.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDScopeUtilities.m[0m
+INFO [2022-09-08 10:49:26.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDResponseTypes.m[0m
+INFO [2022-09-08 10:49:26.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDRegistrationResponse.m[0m
+INFO [2022-09-08 10:49:26.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDRegistrationRequest.m[0m
+INFO [2022-09-08 10:49:26.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDIDToken.m[0m
+INFO [2022-09-08 10:49:26.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDGrantTypes.m[0m
+INFO [2022-09-08 10:49:26.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDFieldMapping.m[0m
+INFO [2022-09-08 10:49:26.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDErrorUtilities.m[0m
+INFO [2022-09-08 10:49:26.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDError.m[0m
+INFO [2022-09-08 10:49:26.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDEndSessionResponse.m[0m
+INFO [2022-09-08 10:49:26.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDEndSessionRequest.m[0m
+INFO [2022-09-08 10:49:26.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDClientMetadataParameters.m[0m
+INFO [2022-09-08 10:49:26.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDAuthorizationService.m[0m
+INFO [2022-09-08 10:49:26.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m ResourceBundle-InAppMessagingDisplayResources-FirebaseInAppMessaging-Info.plist[0m
+INFO [2022-09-08 10:49:26.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDAuthorizationResponse.m[0m
+INFO [2022-09-08 10:49:26.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDAuthorizationRequest.m[0m
+INFO [2022-09-08 10:49:26.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDAuthState.m[0m
+INFO [2022-09-08 10:49:26.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDRedirectHTTPHandler.m[0m
+INFO [2022-09-08 10:49:26.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m BikemapCore.o[0m
+INFO [2022-09-08 10:49:26.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDLoopbackHTTPServer.m[0m
+INFO [2022-09-08 10:49:26.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDExternalUserAgentMac.m[0m
+INFO [2022-09-08 10:49:26.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m BikemapCore.o[0m
+INFO [2022-09-08 10:49:26.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDExternalUserAgentIOSCustomBrowser.m[0m
+INFO [2022-09-08 10:49:26.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDExternalUserAgentCatalyst.m[0m
+INFO [2022-09-08 10:49:26.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDAuthorizationService+Mac.m[0m
+INFO [2022-09-08 10:49:26.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDAuthorizationService+IOS.m[0m
+INFO [2022-09-08 10:49:26.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDAuthState+Mac.m[0m
+INFO [2022-09-08 10:49:26.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OIDAuthState+IOS.m[0m
+INFO [2022-09-08 10:49:26.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m AppAuthCore.o[0m
+INFO [2022-09-08 10:49:26.70]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m InAppMessagingDisplayResources.bundle (in target 'FirebaseInAppMessaging-InAppMessagingDisplayResources' from project 'Pods')[0m
+INFO [2022-09-08 10:49:26.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m BikemapCore.o[0m
+INFO [2022-09-08 10:49:26.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m FirebaseInAppMessaging-Info.plist[0m
+INFO [2022-09-08 10:49:26.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/FirebaseInAppMessaging/FirebaseInAppMessaging.framework/InAppMessagingDisplayResources.bundle[0m
+INFO [2022-09-08 10:49:26.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FirebaseInAppMessaging[0m
+INFO [2022-09-08 10:49:26.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m GTMAppAuth.o[0m
+INFO [2022-09-08 10:49:26.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Check Pods Manifest.lock'[0m
+INFO [2022-09-08 10:49:26.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Alamofire-umbrella.h[0m
+INFO [2022-09-08 10:49:26.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Alamofire-Info.plist[0m
+INFO [2022-09-08 10:49:26.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/ProximaNova-Xbold.otf[0m
+INFO [2022-09-08 10:49:26.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/ProximaNova-Semibold.otf[0m
+INFO [2022-09-08 10:49:26.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/ProximaNova-RegIt.otf[0m
+INFO [2022-09-08 10:49:26.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/ProximaNova-Reg.otf[0m
+INFO [2022-09-08 10:49:26.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/ProximaNova-LightIt.otf[0m
+INFO [2022-09-08 10:49:26.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/ProximaNova-Light.otf[0m
+INFO [2022-09-08 10:49:26.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/ProximaNova-BoldIt.otf[0m
+INFO [2022-09-08 10:49:26.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/ProximaNova-Bold.otf[0m
+INFO [2022-09-08 10:49:26.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/ProximaNova-Black.otf[0m
+INFO [2022-09-08 10:49:26.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/BikemapMono-Bold.ttf[0m
+INFO [2022-09-08 10:49:26.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE\ Extension.appex/BikemapCore[0m
+INFO [2022-09-08 10:49:27.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:27.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:27.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:27.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:27.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:27.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:27.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:27.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:27.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:27.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m InfoPlist.strings[0m
+INFO [2022-09-08 10:49:27.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:27.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m ProximaNova.plist[0m
+INFO [2022-09-08 10:49:28.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Exports.swift[0m
+INFO [2022-09-08 10:49:28.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m AppAuth.o[0m
+INFO [2022-09-08 10:49:28.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Trim.swift[0m
+INFO [2022-09-08 10:49:28.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Unique.swift[0m
+INFO [2022-09-08 10:49:28.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Windows.swift[0m
+INFO [2022-09-08 10:49:28.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Intersperse.swift[0m
+INFO [2022-09-08 10:49:28.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Joined.swift[0m
+INFO [2022-09-08 10:49:28.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MinMax.swift[0m
+INFO [2022-09-08 10:49:28.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AdjacentPairs.swift[0m
+INFO [2022-09-08 10:49:28.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Chain.swift[0m
+INFO [2022-09-08 10:49:28.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Chunked.swift[0m
+INFO [2022-09-08 10:49:28.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Combinations.swift[0m
+INFO [2022-09-08 10:49:28.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RandomSample.swift[0m
+INFO [2022-09-08 10:49:28.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Reductions.swift[0m
+INFO [2022-09-08 10:49:28.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Rotate.swift[0m
+INFO [2022-09-08 10:49:28.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Compacted.swift[0m
+INFO [2022-09-08 10:49:28.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Cycle.swift[0m
+INFO [2022-09-08 10:49:28.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EitherSequence.swift[0m
+INFO [2022-09-08 10:49:33.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Info.plist[0m
+INFO [2022-09-08 10:49:33.40]: ▸ [0;35;49m    [0m[0;35;49m'CLKComplicationSupportedFamilies' has been deprecated starting in watchOS 7.0, use the ClockKit complications API instead. (in target 'Watch-SE Extension' from project 'Bikemap')[0m
+INFO [2022-09-08 10:49:33.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchBikeComputerLocationStore.swift[0m
+INFO [2022-09-08 10:49:34.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Double+Bikemap.swift[0m
+INFO [2022-09-08 10:49:34.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchScreenTitleView.swift[0m
+INFO [2022-09-08 10:49:34.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array+Bikemap.swift[0m
+INFO [2022-09-08 10:49:34.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecordingSyncStore.swift[0m
+INFO [2022-09-08 10:49:34.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LocationWrapper.swift[0m
+INFO [2022-09-08 10:49:34.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchComplications.swift[0m
+INFO [2022-09-08 10:49:34.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchEndRecordingView.swift[0m
+INFO [2022-09-08 10:49:34.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchWorkoutManager.swift[0m
+INFO [2022-09-08 10:49:34.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecordingDidChangePayload.swift[0m
+INFO [2022-09-08 10:49:34.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchStorage.swift[0m
+INFO [2022-09-08 10:49:34.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchConnectivityManager.swift[0m
+INFO [2022-09-08 10:49:34.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WatchBikeComputerSmallParameter.swift[0m
+INFO [2022-09-08 10:49:34.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecStartView.swift[0m
+INFO [2022-09-08 10:49:34.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ComplicationController.swift[0m
+INFO [2022-09-08 10:49:34.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWorkoutStatisticPayload.swift[0m
+INFO [2022-09-08 10:49:34.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchMessagePayloadProtocol.swift[0m
+INFO [2022-09-08 10:49:34.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchUserDefaultsKeys.swift[0m
+INFO [2022-09-08 10:49:34.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchBikeComputerLocationStore.swift[0m
+INFO [2022-09-08 10:49:34.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Double+Bikemap.swift[0m
+INFO [2022-09-08 10:49:34.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchScreenTitleView.swift[0m
+INFO [2022-09-08 10:49:34.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array+Bikemap.swift[0m
+INFO [2022-09-08 10:49:34.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecordingSyncStore.swift[0m
+INFO [2022-09-08 10:49:34.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LocationWrapper.swift[0m
+INFO [2022-09-08 10:49:34.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchComplications.swift[0m
+INFO [2022-09-08 10:49:34.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchEndRecordingView.swift[0m
+INFO [2022-09-08 10:49:34.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchWorkoutManager.swift[0m
+INFO [2022-09-08 10:49:34.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchLayoutConstants.swift[0m
+INFO [2022-09-08 10:49:34.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Config.swift[0m
+INFO [2022-09-08 10:49:34.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Fonts.swift[0m
+INFO [2022-09-08 10:49:34.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFullCircleToLine.swift[0m
+INFO [2022-09-08 10:49:34.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsRecordMode.swift[0m
+INFO [2022-09-08 10:49:34.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTemplateProvider.swift[0m
+INFO [2022-09-08 10:49:34.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchBikeComputerStoreProtocol.swift[0m
+INFO [2022-09-08 10:49:34.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProximaNovaFont.swift[0m
+INFO [2022-09-08 10:49:34.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMHealthKit.swift[0m
+INFO [2022-09-08 10:49:34.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Assets.swift[0m
+INFO [2022-09-08 10:49:34.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchNotificationName.swift[0m
+INFO [2022-09-08 10:49:34.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSignInStatePayload.swift[0m
+INFO [2022-09-08 10:49:34.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnitConverter+Bikemap.swift[0m
+INFO [2022-09-08 10:49:34.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager+Support.swift[0m
+INFO [2022-09-08 10:49:34.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m log.swift[0m
+INFO [2022-09-08 10:49:34.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationRequest.swift[0m
+INFO [2022-09-08 10:49:35.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchRideCellModel.swift[0m
+INFO [2022-09-08 10:49:35.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchLayoutConstants.swift[0m
+INFO [2022-09-08 10:49:35.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Config.swift[0m
+INFO [2022-09-08 10:49:35.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Fonts.swift[0m
+INFO [2022-09-08 10:49:35.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFullCircleToLine.swift[0m
+INFO [2022-09-08 10:49:35.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsRecordMode.swift[0m
+INFO [2022-09-08 10:49:35.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTemplateProvider.swift[0m
+INFO [2022-09-08 10:49:35.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchBikeComputerStoreProtocol.swift[0m
+INFO [2022-09-08 10:49:35.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProximaNovaFont.swift[0m
+INFO [2022-09-08 10:49:35.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMHealthKit.swift[0m
+INFO [2022-09-08 10:49:35.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Assets.swift[0m
+INFO [2022-09-08 10:49:35.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchNotificationName.swift[0m
+INFO [2022-09-08 10:49:35.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSignInStatePayload.swift[0m
+INFO [2022-09-08 10:49:35.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnitConverter+Bikemap.swift[0m
+INFO [2022-09-08 10:49:35.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager+Support.swift[0m
+INFO [2022-09-08 10:49:35.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m log.swift[0m
+INFO [2022-09-08 10:49:35.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationRequest.swift[0m
+INFO [2022-09-08 10:49:35.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchRideCellModel.swift[0m
+INFO [2022-09-08 10:49:35.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CLLocation+Bikemap.swift[0m
+INFO [2022-09-08 10:49:35.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchRideCell.swift[0m
+INFO [2022-09-08 10:49:35.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WatchRideStatisticView.swift[0m
+INFO [2022-09-08 10:49:35.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchMessage.swift[0m
+INFO [2022-09-08 10:49:35.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideArchive.swift[0m
+INFO [2022-09-08 10:49:35.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchAppStore.swift[0m
+INFO [2022-09-08 10:49:35.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NotificationView.swift[0m
+INFO [2022-09-08 10:49:35.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProcessInfo+UITest.swift[0m
+INFO [2022-09-08 10:49:35.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Watch-SE\ Extension_vers.c[0m
+INFO [2022-09-08 10:49:35.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Watch-SE\ Extension_vers.c[0m
+INFO [2022-09-08 10:49:35.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchAlert.swift[0m
+INFO [2022-09-08 10:49:35.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SharedUserDefaultsKeys.swift[0m
+INFO [2022-09-08 10:49:35.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBasicEventType.swift[0m
+INFO [2022-09-08 10:49:35.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WatchGaugeView.swift[0m
+INFO [2022-09-08 10:49:35.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhoneAppStatePayload.swift[0m
+INFO [2022-09-08 10:49:35.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsBasicEventPayload.swift[0m
+INFO [2022-09-08 10:49:35.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhoneSettingsPayload.swift[0m
+INFO [2022-09-08 10:49:35.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserDefaults.swift[0m
+INFO [2022-09-08 10:49:35.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchConnectivity.swift[0m
+INFO [2022-09-08 10:49:35.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchRecordingControlView.swift[0m
+INFO [2022-09-08 10:49:35.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchComplicationPayload.swift[0m
+INFO [2022-09-08 10:49:35.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchBikeComputerStore.swift[0m
+INFO [2022-09-08 10:49:35.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager.swift[0m
+INFO [2022-09-08 10:49:35.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPeakMeterView.swift[0m
+INFO [2022-09-08 10:49:35.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMConnectivityManager.swift[0m
+INFO [2022-09-08 10:49:35.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NotificationController.swift[0m
+INFO [2022-09-08 10:49:35.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WatchSpeedView.swift[0m
+INFO [2022-09-08 10:49:35.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSharedRidePayload.swift[0m
+INFO [2022-09-08 10:49:35.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchAlert.swift[0m
+INFO [2022-09-08 10:49:35.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SharedUserDefaultsKeys.swift[0m
+INFO [2022-09-08 10:49:35.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBasicEventType.swift[0m
+INFO [2022-09-08 10:49:35.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WatchGaugeView.swift[0m
+INFO [2022-09-08 10:49:35.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhoneAppStatePayload.swift[0m
+INFO [2022-09-08 10:49:35.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsBasicEventPayload.swift[0m
+INFO [2022-09-08 10:49:35.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhoneSettingsPayload.swift[0m
+INFO [2022-09-08 10:49:35.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserDefaults.swift[0m
+INFO [2022-09-08 10:49:35.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchConnectivity.swift[0m
+INFO [2022-09-08 10:49:35.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchRecordingControlView.swift[0m
+INFO [2022-09-08 10:49:36.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchComplicationPayload.swift[0m
+INFO [2022-09-08 10:49:36.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchBikeComputerStore.swift[0m
+INFO [2022-09-08 10:49:36.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager.swift[0m
+INFO [2022-09-08 10:49:36.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPeakMeterView.swift[0m
+INFO [2022-09-08 10:49:36.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMConnectivityManager.swift[0m
+INFO [2022-09-08 10:49:36.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NotificationController.swift[0m
+INFO [2022-09-08 10:49:36.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WatchSpeedView.swift[0m
+INFO [2022-09-08 10:49:36.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSharedRidePayload.swift[0m
+INFO [2022-09-08 10:49:36.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecordingDidChangePayload.swift[0m
+INFO [2022-09-08 10:49:36.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchStorage.swift[0m
+INFO [2022-09-08 10:49:36.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchConnectivityManager.swift[0m
+INFO [2022-09-08 10:49:36.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WatchBikeComputerSmallParameter.swift[0m
+INFO [2022-09-08 10:49:36.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecStartView.swift[0m
+INFO [2022-09-08 10:49:36.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ComplicationController.swift[0m
+INFO [2022-09-08 10:49:36.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWorkoutStatisticPayload.swift[0m
+INFO [2022-09-08 10:49:36.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchMessagePayloadProtocol.swift[0m
+INFO [2022-09-08 10:49:36.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchUserDefaultsKeys.swift[0m
+INFO [2022-09-08 10:49:36.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CLLocation+Bikemap.swift[0m
+INFO [2022-09-08 10:49:36.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchRideCell.swift[0m
+INFO [2022-09-08 10:49:36.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WatchRideStatisticView.swift[0m
+INFO [2022-09-08 10:49:36.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchMessage.swift[0m
+INFO [2022-09-08 10:49:36.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideArchive.swift[0m
+INFO [2022-09-08 10:49:36.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchAppStore.swift[0m
+INFO [2022-09-08 10:49:36.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NotificationView.swift[0m
+INFO [2022-09-08 10:49:36.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProcessInfo+UITest.swift[0m
+INFO [2022-09-08 10:49:36.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFinishedRidePayload.swift[0m
+INFO [2022-09-08 10:49:37.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSensors.swift[0m
+INFO [2022-09-08 10:49:37.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchSetupView.swift[0m
+INFO [2022-09-08 10:49:37.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMQueryActiveStatePayload.swift[0m
+INFO [2022-09-08 10:49:37.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m String+Bikemap.swift[0m
+INFO [2022-09-08 10:49:37.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideData.swift[0m
+INFO [2022-09-08 10:49:37.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchAppRideStore.swift[0m
+INFO [2022-09-08 10:49:37.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikemapApp.swift[0m
+INFO [2022-09-08 10:49:37.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecordedRidesView.swift[0m
+INFO [2022-09-08 10:49:37.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFinishedRidePayload.swift[0m
+INFO [2022-09-08 10:49:37.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSensors.swift[0m
+INFO [2022-09-08 10:49:37.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchSetupView.swift[0m
+INFO [2022-09-08 10:49:37.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMQueryActiveStatePayload.swift[0m
+INFO [2022-09-08 10:49:37.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m String+Bikemap.swift[0m
+INFO [2022-09-08 10:49:37.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideData.swift[0m
+INFO [2022-09-08 10:49:37.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchAppRideStore.swift[0m
+INFO [2022-09-08 10:49:37.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikemapApp.swift[0m
+INFO [2022-09-08 10:49:37.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecordedRidesView.swift[0m
+INFO [2022-09-08 10:49:37.27]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m FirebaseInAppMessaging.framework (in target 'FirebaseInAppMessaging' from project 'Pods')[0m
+INFO [2022-09-08 10:49:37.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Split.swift[0m
+INFO [2022-09-08 10:49:37.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stride.swift[0m
+INFO [2022-09-08 10:49:37.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Suffix.swift[0m
+INFO [2022-09-08 10:49:37.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Partition.swift[0m
+INFO [2022-09-08 10:49:37.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Permutations.swift[0m
+INFO [2022-09-08 10:49:37.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Product.swift[0m
+INFO [2022-09-08 10:49:37.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FacebookAEM.o[0m
+INFO [2022-09-08 10:49:37.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FirstNonNil.swift[0m
+INFO [2022-09-08 10:49:37.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FlattenCollection.swift[0m
+INFO [2022-09-08 10:49:37.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Indexed.swift[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m fwd.h[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m UIViewController+AnyPromise.h[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m UIView+AnyPromise.h[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m PromiseKit.h[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m PromiseKit-umbrella.h[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m PMKUIKit.h[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m PMKFoundation.h[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m NSURLSession+AnyPromise.h[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m NSTask+AnyPromise.h[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m NSNotificationCenter+AnyPromise.h[0m
+INFO [2022-09-08 10:49:37.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m AnyPromise.h[0m
+INFO [2022-09-08 10:49:39.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Exports.swift[0m
+INFO [2022-09-08 10:49:39.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Imports.swift[0m
+INFO [2022-09-08 10:49:40.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m GoogleSignIn.o[0m
+INFO [2022-09-08 10:49:40.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Algorithms.o[0m
+INFO [2022-09-08 10:49:40.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Alamofire_vers.c[0m
+INFO [2022-09-08 10:49:40.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Alamofire-dummy.m[0m
+INFO [2022-09-08 10:49:40.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ServerTrustPolicy.swift[0m
+INFO [2022-09-08 10:49:40.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SessionDelegate.swift[0m
+INFO [2022-09-08 10:49:40.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m AlamofireImage-umbrella.h[0m
+INFO [2022-09-08 10:49:40.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AnyPromise.swift[0m
+INFO [2022-09-08 10:49:41.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Box.swift[0m
+INFO [2022-09-08 10:49:41.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Catchable.swift[0m
+INFO [2022-09-08 10:49:41.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m after.swift[0m
+INFO [2022-09-08 10:49:41.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m afterlife.swift[0m
+INFO [2022-09-08 10:49:41.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Alamofire+Promise.swift[0m
+INFO [2022-09-08 10:49:41.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Watch-SE\[0m
+INFO [2022-09-08 10:49:57.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+Promise.swift[0m
+INFO [2022-09-08 10:49:57.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIViewPropertyAnimator+Promise.swift[0m
+INFO [2022-09-08 10:49:57.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m when.swift[0m
+INFO [2022-09-08 10:49:57.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Watch-SE\[0m
+INFO [2022-09-08 10:49:57.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Configuration.swift[0m
+INFO [2022-09-08 10:49:57.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CustomStringConvertible.swift[0m
+INFO [2022-09-08 10:49:57.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Deprecations.swift[0m
+INFO [2022-09-08 10:49:57.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSURLSession+Promise.swift[0m
+INFO [2022-09-08 10:49:57.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Process+Promise.swift[0m
+INFO [2022-09-08 10:49:57.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Promise.swift[0m
+INFO [2022-09-08 10:49:57.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m hang.swift[0m
+INFO [2022-09-08 10:49:57.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSNotificationCenter+Promise.swift[0m
+INFO [2022-09-08 10:49:57.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSObject+Promise.swift[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m when.m[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m race.m[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Watch-SE\ Extension.appex (in target 'Watch-SE Extension' from project 'Bikemap')[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m join.m[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m hang.m[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m dispatch_promise.m[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Check Pods Manifest.lock'[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m after.m[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIViewController+AnyPromise.m[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+AnyPromise.m[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PromiseKit_vers.c[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PromiseKit-dummy.m[0m
+INFO [2022-09-08 10:49:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSURLSession+AnyPromise.m[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSTask+AnyPromise.m[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSNotificationCenter+AnyPromise.m[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-watchsimulator/Watch-SE.app/BikemapCore[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:49:57.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AnyPromise.m[0m
+INFO [2022-09-08 10:49:57.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Error.swift[0m
+INFO [2022-09-08 10:49:57.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m firstly.swift[0m
+INFO [2022-09-08 10:49:57.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Guarantee.swift[0m
+INFO [2022-09-08 10:49:57.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m race.swift[0m
+INFO [2022-09-08 10:49:57.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Resolver.swift[0m
+INFO [2022-09-08 10:49:57.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Thenable.swift[0m
+INFO [2022-09-08 10:49:57.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Animator.swift[0m
+INFO [2022-09-08 10:50:04.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartAnimationEasing.swift[0m
+INFO [2022-09-08 10:50:04.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarChartView.swift[0m
+INFO [2022-09-08 10:50:04.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarLineChartViewBase.swift[0m
+INFO [2022-09-08 10:50:04.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BubbleChartView.swift[0m
+INFO [2022-09-08 10:50:04.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CandleStickChartView.swift[0m
+INFO [2022-09-08 10:50:04.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartViewBase.swift[0m
+INFO [2022-09-08 10:50:04.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CombinedChartView.swift[0m
+INFO [2022-09-08 10:50:04.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HorizontalBarChartView.swift[0m
+INFO [2022-09-08 10:50:04.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineChartView.swift[0m
+INFO [2022-09-08 10:50:04.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PieChartView.swift[0m
+INFO [2022-09-08 10:50:04.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PieRadarChartViewBase.swift[0m
+INFO [2022-09-08 10:50:04.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RadarChartView.swift[0m
+INFO [2022-09-08 10:50:04.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ScatterChartView.swift[0m
+INFO [2022-09-08 10:50:04.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AxisBase.swift[0m
+INFO [2022-09-08 10:50:04.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartLimitLine.swift[0m
+INFO [2022-09-08 10:50:04.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ComponentBase.swift[0m
+INFO [2022-09-08 10:50:04.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Description.swift[0m
+INFO [2022-09-08 10:50:04.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FacebookCore.o[0m
+INFO [2022-09-08 10:50:04.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IndexAxisValueFormatter.swift[0m
+INFO [2022-09-08 10:50:04.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ValueFormatter.swift[0m
+INFO [2022-09-08 10:50:04.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarHighlighter.swift[0m
+INFO [2022-09-08 10:50:04.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartHighlighter.swift[0m
+INFO [2022-09-08 10:50:04.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CombinedHighlighter.swift[0m
+INFO [2022-09-08 10:50:04.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Highlight.swift[0m
+INFO [2022-09-08 10:50:04.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Highlighter.swift[0m
+INFO [2022-09-08 10:50:04.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HorizontalBarHighlighter.swift[0m
+INFO [2022-09-08 10:50:04.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PieHighlighter.swift[0m
+INFO [2022-09-08 10:50:04.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PieRadarHighlighter.swift[0m
+INFO [2022-09-08 10:50:04.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RadarHighlighter.swift[0m
+INFO [2022-09-08 10:50:04.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Range.swift[0m
+INFO [2022-09-08 10:50:04.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarChartDataProvider.swift[0m
+INFO [2022-09-08 10:50:04.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarLineScatterCandleBubbleChartDataProvider.swift[0m
+INFO [2022-09-08 10:50:04.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BubbleChartDataProvider.swift[0m
+INFO [2022-09-08 10:50:04.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CandleChartDataProvider.swift[0m
+INFO [2022-09-08 10:50:04.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartDataProvider.swift[0m
+INFO [2022-09-08 10:50:04.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CombinedChartDataProvider.swift[0m
+INFO [2022-09-08 10:50:04.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Legend.swift[0m
+INFO [2022-09-08 10:50:04.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LegendEntry.swift[0m
+INFO [2022-09-08 10:50:04.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Marker.swift[0m
+INFO [2022-09-08 10:50:04.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MarkerImage.swift[0m
+INFO [2022-09-08 10:50:04.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MarkerView.swift[0m
+INFO [2022-09-08 10:50:04.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m XAxis.swift[0m
+INFO [2022-09-08 10:50:04.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YAxis.swift[0m
+INFO [2022-09-08 10:50:04.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartBaseDataSet.swift[0m
+INFO [2022-09-08 10:50:04.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarChartData.swift[0m
+INFO [2022-09-08 10:50:04.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarChartDataEntry.swift[0m
+INFO [2022-09-08 10:50:04.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarLineScatterCandleBubbleChartData.swift[0m
+INFO [2022-09-08 10:50:04.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarLineScatterCandleBubbleChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BubbleChartData.swift[0m
+INFO [2022-09-08 10:50:04.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BubbleChartDataEntry.swift[0m
+INFO [2022-09-08 10:50:04.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BubbleChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CandleChartData.swift[0m
+INFO [2022-09-08 10:50:04.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CandleChartDataEntry.swift[0m
+INFO [2022-09-08 10:50:04.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Exports.swift[0m
+INFO [2022-09-08 10:50:04.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineChartRenderer.swift[0m
+INFO [2022-09-08 10:50:04.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineRadarRenderer.swift[0m
+INFO [2022-09-08 10:50:04.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineScatterCandleRadarRenderer.swift[0m
+INFO [2022-09-08 10:50:04.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PieChartRenderer.swift[0m
+INFO [2022-09-08 10:50:04.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RadarChartRenderer.swift[0m
+INFO [2022-09-08 10:50:04.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Renderer.swift[0m
+INFO [2022-09-08 10:50:04.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChevronDownShapeRenderer.swift[0m
+INFO [2022-09-08 10:50:04.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChevronUpShapeRenderer.swift[0m
+INFO [2022-09-08 10:50:04.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CircleShapeRenderer.swift[0m
+INFO [2022-09-08 10:50:04.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CrossShapeRenderer.swift[0m
+INFO [2022-09-08 10:50:04.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ShapeRenderer.swift[0m
+INFO [2022-09-08 10:50:04.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SquareShapeRenderer.swift[0m
+INFO [2022-09-08 10:50:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TriangleShapeRenderer.swift[0m
+INFO [2022-09-08 10:50:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m XShapeRenderer.swift[0m
+INFO [2022-09-08 10:50:04.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ScatterChartRenderer.swift[0m
+INFO [2022-09-08 10:50:04.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m XAxisRenderer.swift[0m
+INFO [2022-09-08 10:50:04.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m XAxisRendererHorizontalBarChart.swift[0m
+INFO [2022-09-08 10:50:04.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineChartDataProvider.swift[0m
+INFO [2022-09-08 10:50:04.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ScatterChartDataProvider.swift[0m
+INFO [2022-09-08 10:50:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AnimatedMoveViewJob.swift[0m
+INFO [2022-09-08 10:50:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AnimatedViewPortJob.swift[0m
+INFO [2022-09-08 10:50:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AnimatedZoomViewJob.swift[0m
+INFO [2022-09-08 10:50:04.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MoveViewJob.swift[0m
+INFO [2022-09-08 10:50:04.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ViewPortJob.swift[0m
+INFO [2022-09-08 10:50:04.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ZoomViewJob.swift[0m
+INFO [2022-09-08 10:50:04.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AxisRenderer.swift[0m
+INFO [2022-09-08 10:50:04.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarChartRenderer.swift[0m
+INFO [2022-09-08 10:50:04.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarLineScatterCandleBubbleRenderer.swift[0m
+INFO [2022-09-08 10:50:04.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BubbleChartRenderer.swift[0m
+INFO [2022-09-08 10:50:04.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CandleStickChartRenderer.swift[0m
+INFO [2022-09-08 10:50:04.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CombinedChartRenderer.swift[0m
+INFO [2022-09-08 10:50:04.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DataRenderer.swift[0m
+INFO [2022-09-08 10:50:04.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HorizontalBarChartRenderer.swift[0m
+INFO [2022-09-08 10:50:04.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LegendRenderer.swift[0m
+INFO [2022-09-08 10:50:04.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BarLineScatterCandleBubbleChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BubbleChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CandleChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineRadarChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineScatterCandleRadarChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PieChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RadarChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ScatterChartDataSetProtocol.swift[0m
+INFO [2022-09-08 10:50:04.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DataApproximator+N.swift[0m
+INFO [2022-09-08 10:50:04.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DataApproximator.swift[0m
+INFO [2022-09-08 10:50:04.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AxisValueFormatter.swift[0m
+INFO [2022-09-08 10:50:04.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DefaultAxisValueFormatter.swift[0m
+INFO [2022-09-08 10:50:04.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DefaultFillFormatter.swift[0m
+INFO [2022-09-08 10:50:04.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DefaultValueFormatter.swift[0m
+INFO [2022-09-08 10:50:04.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FillFormatter.swift[0m
+INFO [2022-09-08 10:50:04.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m XAxisRendererRadarChart.swift[0m
+INFO [2022-09-08 10:50:04.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YAxisRenderer.swift[0m
+INFO [2022-09-08 10:50:04.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YAxisRendererHorizontalBarChart.swift[0m
+INFO [2022-09-08 10:50:04.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m YAxisRendererRadarChart.swift[0m
+INFO [2022-09-08 10:50:04.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartColorTemplates.swift[0m
+INFO [2022-09-08 10:50:04.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartUtils.swift[0m
+INFO [2022-09-08 10:50:04.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Fill.swift[0m
+INFO [2022-09-08 10:50:04.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Platform+Accessibility.swift[0m
+INFO [2022-09-08 10:50:04.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Platform+Color.swift[0m
+INFO [2022-09-08 10:50:04.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Platform+Gestures.swift[0m
+INFO [2022-09-08 10:50:04.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Platform+Graphics.swift[0m
+INFO [2022-09-08 10:50:04.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Platform+Touch\ Handling.swift[0m
+INFO [2022-09-08 10:50:04.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Platform.swift[0m
+INFO [2022-09-08 10:50:04.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Sequence+KeyPath.swift[0m
+INFO [2022-09-08 10:50:04.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Transformer.swift[0m
+INFO [2022-09-08 10:50:04.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TransformerHorizontalBarChart.swift[0m
+INFO [2022-09-08 10:50:04.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ViewPortHandler.swift[0m
+INFO [2022-09-08 10:50:04.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Info.plist[0m
+INFO [2022-09-08 10:50:04.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CandleChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartData.swift[0m
+INFO [2022-09-08 10:50:04.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartDataEntry.swift[0m
+INFO [2022-09-08 10:50:04.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartDataEntryBase.swift[0m
+INFO [2022-09-08 10:50:04.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CombinedChartData.swift[0m
+INFO [2022-09-08 10:50:04.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineChartData.swift[0m
+INFO [2022-09-08 10:50:04.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineRadarChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LineScatterCandleRadarChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PieChartData.swift[0m
+INFO [2022-09-08 10:50:04.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PieChartDataEntry.swift[0m
+INFO [2022-09-08 10:50:04.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PieChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RadarChartData.swift[0m
+INFO [2022-09-08 10:50:04.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RadarChartDataEntry.swift[0m
+INFO [2022-09-08 10:50:04.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RadarChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ScatterChartData.swift[0m
+INFO [2022-09-08 10:50:04.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ScatterChartDataSet.swift[0m
+INFO [2022-09-08 10:50:04.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m FacebookLogin.o[0m
+INFO [2022-09-08 10:50:04.66]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Watch-SE.app (in target 'Watch-SE' from project 'Bikemap')[0m
+INFO [2022-09-08 10:50:04.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MultipartFormData.swift[0m
+INFO [2022-09-08 10:50:04.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NetworkReachabilityManager.swift[0m
+INFO [2022-09-08 10:50:04.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m AwaitKit-umbrella.h[0m
+INFO [2022-09-08 10:50:04.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Timeline.swift[0m
+INFO [2022-09-08 10:50:04.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Validation.swift[0m
+INFO [2022-09-08 10:50:04.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageCache.swift[0m
+INFO [2022-09-08 10:50:04.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Request+AlamofireImage.swift[0m
+INFO [2022-09-08 10:50:04.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AFIError.swift[0m
+INFO [2022-09-08 10:50:04.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Image.swift[0m
+INFO [2022-09-08 10:50:04.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIImageView+AlamofireImage.swift[0m
+INFO [2022-09-08 10:50:04.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AwaitKitExtension.swift[0m
+INFO [2022-09-08 10:50:04.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DispatchQueue+Await.swift[0m
+INFO [2022-09-08 10:50:04.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AwaitKit.swift[0m
+INFO [2022-09-08 10:50:04.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DispatchQueue+Async.swift[0m
+INFO [2022-09-08 10:50:04.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIButton+AlamofireImage.swift[0m
+INFO [2022-09-08 10:50:04.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageFilter.swift[0m
+INFO [2022-09-08 10:50:04.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIImage+AlamofireImage.swift[0m
+INFO [2022-09-08 10:50:04.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ImageDownloader.swift[0m
+INFO [2022-09-08 10:50:04.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notifications.swift[0m
+INFO [2022-09-08 10:50:04.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ParameterEncoding.swift[0m
+INFO [2022-09-08 10:50:04.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AFError.swift[0m
+INFO [2022-09-08 10:50:04.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Alamofire.swift[0m
+INFO [2022-09-08 10:50:04.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DispatchQueue+Alamofire.swift[0m
+INFO [2022-09-08 10:50:04.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ResponseSerialization.swift[0m
+INFO [2022-09-08 10:50:04.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Result.swift[0m
+INFO [2022-09-08 10:50:04.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SessionManager.swift[0m
+INFO [2022-09-08 10:50:04.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TaskDelegate.swift[0m
+INFO [2022-09-08 10:50:04.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Request.swift[0m
+INFO [2022-09-08 10:50:04.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Response.swift[0m
+INFO [2022-09-08 10:50:04.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AlamofireImage_vers.c[0m
+INFO [2022-09-08 10:50:04.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AwaitKit_vers.c[0m
+INFO [2022-09-08 10:50:04.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AwaitKit-dummy.m[0m
+INFO [2022-09-08 10:50:04.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AlamofireImage-dummy.m[0m
+INFO [2022-09-08 10:50:04.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Pods-Bikemap-umbrella.h[0m
+INFO [2022-09-08 10:50:04.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods-Bikemap-dummy.m[0m
+INFO [2022-09-08 10:50:04.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods_Bikemap_vers.c[0m
+INFO [2022-09-08 10:50:04.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Pods-BikemapTests-umbrella.h[0m
+INFO [2022-09-08 10:50:04.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods-BikemapTests-dummy.m[0m
+INFO [2022-09-08 10:50:04.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Pods_BikemapTests_vers.c[0m
+INFO [2022-09-08 10:50:04.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Alamofire[0m
+INFO [2022-09-08 10:50:04.78]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Alamofire.framework (in target 'Alamofire' from project 'Pods')[0m
+INFO [2022-09-08 10:50:04.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m PromiseKit-Info.plist[0m
+INFO [2022-09-08 10:50:04.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m AlamofireImage-Info.plist[0m
+INFO [2022-09-08 10:50:04.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m PromiseKit[0m
+INFO [2022-09-08 10:50:04.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m AlamofireImage[0m
+INFO [2022-09-08 10:50:04.79]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m PromiseKit.framework (in target 'PromiseKit' from project 'Pods')[0m
+INFO [2022-09-08 10:50:04.79]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m AlamofireImage.framework (in target 'AlamofireImage' from project 'Pods')[0m
+INFO [2022-09-08 10:50:04.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m AwaitKit-Info.plist[0m
+INFO [2022-09-08 10:50:04.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m AwaitKit[0m
+INFO [2022-09-08 10:50:04.79]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m AwaitKit.framework (in target 'AwaitKit' from project 'Pods')[0m
+INFO [2022-09-08 10:50:04.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Pods-Bikemap-Info.plist[0m
+INFO [2022-09-08 10:50:04.79]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Pods_Bikemap.framework (in target 'Pods-Bikemap' from project 'Pods')[0m
+INFO [2022-09-08 10:50:04.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Pods-BikemapTests-Info.plist[0m
+INFO [2022-09-08 10:50:04.79]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Pods_BikemapTests.framework (in target 'Pods-BikemapTests' from project 'Pods')[0m
+INFO [2022-09-08 10:50:05.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Charts.o[0m
+INFO [2022-09-08 10:50:05.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Check Pods Manifest.lock'[0m
+INFO [2022-09-08 10:50:05.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m 'Setup Githooks for BartyCrouch'[0m
+INFO [2022-09-08 10:50:06.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Intents.strings[0m
+INFO [2022-09-08 10:50:06.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Intents.strings[0m
+INFO [2022-09-08 10:50:06.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Intents.strings[0m
+INFO [2022-09-08 10:50:06.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Intents.strings[0m
+INFO [2022-09-08 10:50:06.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Intents.strings[0m
+INFO [2022-09-08 10:50:06.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Intents.strings[0m
+INFO [2022-09-08 10:50:06.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Intents.strings[0m
+INFO [2022-09-08 10:50:06.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Intents.strings[0m
+INFO [2022-09-08 10:50:06.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Intents.strings[0m
+INFO [2022-09-08 10:50:06.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Intents.strings[0m
+INFO [2022-09-08 10:50:11.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnnotation.swift[0m
+INFO [2022-09-08 10:50:33.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TitleSupplementaryView.swift[0m
+INFO [2022-09-08 10:50:33.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route+Delete.swift[0m
+INFO [2022-09-08 10:50:33.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRoutingConfigurationDecoder.swift[0m
+INFO [2022-09-08 10:50:33.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMElevationAnnotation.swift[0m
+INFO [2022-09-08 10:50:33.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SelfSizingHostingController.swift[0m
+INFO [2022-09-08 10:50:33.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsExpireAccessToken.swift[0m
+INFO [2022-09-08 10:50:33.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CollectionImageBackgroundView.swift[0m
+INFO [2022-09-08 10:50:33.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProgressActivity.swift[0m
+INFO [2022-09-08 10:50:33.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSensors.swift[0m
+INFO [2022-09-08 10:50:33.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ViewBuilders.swift[0m
+INFO [2022-09-08 10:50:33.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteStylesManager.swift[0m
+INFO [2022-09-08 10:50:33.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailsViewController+Offline.swift[0m
+INFO [2022-09-08 10:50:33.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteLocalFilter.swift[0m
+INFO [2022-09-08 10:50:33.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+Heading.swift[0m
+INFO [2022-09-08 10:50:33.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSelectablePin.swift[0m
+INFO [2022-09-08 10:50:33.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMyActivityWeeklyTotalLabel.swift[0m
+INFO [2022-09-08 10:50:34.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array+Bikemap.swift[0m
+INFO [2022-09-08 10:50:34.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOIUploadParameters.swift[0m
+INFO [2022-09-08 10:50:34.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideWaypointsViewController.swift[0m
+INFO [2022-09-08 10:50:34.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Turf+Extensions.swift[0m
+INFO [2022-09-08 10:50:34.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSnapshotMapView.swift[0m
+INFO [2022-09-08 10:50:34.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MyRoutesSectionView.swift[0m
+INFO [2022-09-08 10:50:34.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailsViewController+ButtonActions.swift[0m
+INFO [2022-09-08 10:50:41.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMConnectivityManager.swift[0m
+INFO [2022-09-08 10:50:41.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPremiumViewController.swift[0m
+INFO [2022-09-08 10:50:41.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route+Bikemap.swift[0m
+INFO [2022-09-08 10:50:41.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAngelSettingsViewController.swift[0m
+INFO [2022-09-08 10:50:41.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNotificationCenter.swift[0m
+INFO [2022-09-08 10:50:41.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UICollectionViewCell+Bikemap.swift[0m
+INFO [2022-09-08 10:50:41.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notification+Trigger.swift[0m
+INFO [2022-09-08 10:50:41.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOICategoryCell.swift[0m
+INFO [2022-09-08 10:50:41.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGPXImporter.swift[0m
+INFO [2022-09-08 10:50:41.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSignUpFlow.swift[0m
+INFO [2022-09-08 10:50:41.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserProgressView.swift[0m
+INFO [2022-09-08 10:50:41.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSpotlightDelegate.swift[0m
+INFO [2022-09-08 10:50:41.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCollectionHeaderView.swift[0m
+INFO [2022-09-08 10:50:41.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSubscriptionAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:50:41.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailCallToActionView.swift[0m
+INFO [2022-09-08 10:50:41.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerBasicElementView.swift[0m
+INFO [2022-09-08 10:50:41.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StreakView.swift[0m
+INFO [2022-09-08 10:50:41.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRouteSizeCalculator.swift[0m
+INFO [2022-09-08 10:50:41.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRegionPickerViewController.swift[0m
+INFO [2022-09-08 10:50:41.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GeoJSONPointGeometry.swift[0m
+INFO [2022-09-08 10:50:41.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRetrySnapshotView.swift[0m
+INFO [2022-09-08 10:50:41.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUIDecorator.swift[0m
+INFO [2022-09-08 10:50:41.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PremiumLoopUserProgressView.swift[0m
+INFO [2022-09-08 10:50:41.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteTableViewCell.swift[0m
+INFO [2022-09-08 10:50:41.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAbstractSocial.swift[0m
+INFO [2022-09-08 10:50:41.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteUploadViewController.swift[0m
+INFO [2022-09-08 10:50:42.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionStatsView.swift[0m
+INFO [2022-09-08 10:50:42.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNotificationCenterBackgroundView.swift[0m
+INFO [2022-09-08 10:50:42.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreDataContextObserver.swift[0m
+INFO [2022-09-08 10:50:42.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionPrivateSection.swift[0m
+INFO [2022-09-08 10:50:42.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchConnectivity.swift[0m
+INFO [2022-09-08 10:50:42.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m User+Routes.swift[0m
+INFO [2022-09-08 10:50:42.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSENavigationViewController.swift[0m
+INFO [2022-09-08 10:50:42.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMGLMapView.swift[0m
+INFO [2022-09-08 10:50:42.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsRemoveRefreshToken.swift[0m
+INFO [2022-09-08 10:50:42.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailsViewController+Polygon.swift[0m
+INFO [2022-09-08 10:50:42.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIButton+Bikemap.swift[0m
+INFO [2022-09-08 10:50:42.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchComplicationPayload.swift[0m
+INFO [2022-09-08 10:50:42.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Reachability.swift[0m
+INFO [2022-09-08 10:50:42.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSocialShareActivityItemSource.swift[0m
+INFO [2022-09-08 10:50:42.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNotificationAction+Settings.swift[0m
+INFO [2022-09-08 10:50:42.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRuleSystems.swift[0m
+INFO [2022-09-08 10:50:42.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AuthSessionMaintainer.swift[0m
+INFO [2022-09-08 10:50:42.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCircuitBreaker.swift[0m
+INFO [2022-09-08 10:50:42.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAppleIDCredentials.swift[0m
+INFO [2022-09-08 10:50:42.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SocialShareViewHelpers.swift[0m
+INFO [2022-09-08 10:50:42.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSignInStatePayload.swift[0m
+INFO [2022-09-08 10:50:42.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMReferAFriendHeader.swift[0m
+INFO [2022-09-08 10:50:42.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineRegion+Bikemap.swift[0m
+INFO [2022-09-08 10:50:42.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCheckAppleIdOperation.swift[0m
+INFO [2022-09-08 10:50:42.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMToggleButton.swift[0m
+INFO [2022-09-08 10:50:42.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UITableViewCell+Bikemap.swift[0m
+INFO [2022-09-08 10:50:42.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+DeepLinks.swift[0m
+INFO [2022-09-08 10:50:42.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchSuggestionTableViewCell.swift[0m
+INFO [2022-09-08 10:50:42.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAccountPickerViewController.swift[0m
+INFO [2022-09-08 10:50:42.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFacebook.swift[0m
+INFO [2022-09-08 10:50:42.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SimplificationPoint.swift[0m
+INFO [2022-09-08 10:50:43.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRatingTrigger.swift[0m
+INFO [2022-09-08 10:50:43.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMHUDView.swift[0m
+INFO [2022-09-08 10:50:43.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDebugPolygon.swift[0m
+INFO [2022-09-08 10:50:43.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRatePOIImageView.swift[0m
+INFO [2022-09-08 10:50:43.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPolygonCalculatorType.swift[0m
+INFO [2022-09-08 10:50:43.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CoreLocation+Bikemap.swift[0m
+INFO [2022-09-08 10:50:43.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserDefaults.swift[0m
+INFO [2022-09-08 10:50:43.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSLocale+Bikemap.swift[0m
+INFO [2022-09-08 10:50:43.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Bundle+Bikemap.swift[0m
+INFO [2022-09-08 10:50:43.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGroupActivityUserRowView.swift[0m
+INFO [2022-09-08 10:50:43.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFeedUpdateManager.swift[0m
+INFO [2022-09-08 10:50:43.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSManagedObjectContext+ChildContext.swift[0m
+INFO [2022-09-08 10:50:43.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CyclingPathsOptionView.swift[0m
+INFO [2022-09-08 10:50:43.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m String+HTML.swift[0m
+INFO [2022-09-08 10:50:43.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserProfileButtonBarView.swift[0m
+INFO [2022-09-08 10:50:43.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMScreenCoordinator.swift[0m
+INFO [2022-09-08 10:50:43.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFeedReloadOperation.swift[0m
+INFO [2022-09-08 10:50:43.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notification+Search.swift[0m
+INFO [2022-09-08 10:50:43.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCredentials+LaunchArguments.swift[0m
+INFO [2022-09-08 10:50:43.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerPlaceholderStore.swift[0m
+INFO [2022-09-08 10:50:43.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CLLocation+Bikemap.swift[0m
+INFO [2022-09-08 10:50:43.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineCyclingPathsCustomModel.swift[0m
+INFO [2022-09-08 10:50:43.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UINavigationController+Bikemap.swift[0m
+INFO [2022-09-08 10:50:43.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAuthSessionStateHolder.swift[0m
+INFO [2022-09-08 10:50:43.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CyclingPathsProfilesOptionsStore.swift[0m
+INFO [2022-09-08 10:50:43.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerElementType.swift[0m
+INFO [2022-09-08 10:50:43.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationPossibleError.swift[0m
+INFO [2022-09-08 10:50:43.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerClockElementView.swift[0m
+INFO [2022-09-08 10:50:44.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMStrippedDirections.swift[0m
+INFO [2022-09-08 10:50:44.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutingProfileCollectionViewCell.swift[0m
+INFO [2022-09-08 10:50:44.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MountTypeClassifier.swift[0m
+INFO [2022-09-08 10:50:44.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTurfFeature.swift[0m
+INFO [2022-09-08 10:50:44.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNetworkRequest.swift[0m
+INFO [2022-09-08 10:50:44.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSensorsAPI.swift[0m
+INFO [2022-09-08 10:50:44.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailsViewController+SocialShare.swift[0m
+INFO [2022-09-08 10:50:44.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLayoutGalleryButton.swift[0m
+INFO [2022-09-08 10:50:44.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailCollectionsView.swift[0m
+INFO [2022-09-08 10:50:44.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchMessage.swift[0m
+INFO [2022-09-08 10:50:44.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerStore.swift[0m
+INFO [2022-09-08 10:50:44.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AngelActivityClassifier.swift[0m
+INFO [2022-09-08 10:50:44.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RDPLocationSimplifier.swift[0m
+INFO [2022-09-08 10:50:44.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:44.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UnitConverter+Bikemap.swift[0m
+INFO [2022-09-08 10:50:44.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSnapshotView.swift[0m
+INFO [2022-09-08 10:50:44.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideFinishRatingView.swift[0m
+INFO [2022-09-08 10:50:44.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDataAccess.swift[0m
+INFO [2022-09-08 10:50:44.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationInstructionsTableViewController.swift[0m
+INFO [2022-09-08 10:50:44.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GraphHopper.swift[0m
+INFO [2022-09-08 10:50:44.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDiscoverViewController.swift[0m
+INFO [2022-09-08 10:50:44.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMQueryActiveStatePayload.swift[0m
+INFO [2022-09-08 10:50:44.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:44.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBasicAnalyticsEvent.swift[0m
+INFO [2022-09-08 10:50:44.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAdAttributionManager.swift[0m
+INFO [2022-09-08 10:50:44.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFinishedRidePayload.swift[0m
+INFO [2022-09-08 10:50:44.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserStore.swift[0m
+INFO [2022-09-08 10:50:44.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOICategoryInteractor.swift[0m
+INFO [2022-09-08 10:50:44.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMyActivityStore.swift[0m
+INFO [2022-09-08 10:50:44.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserProfileAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:50:44.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFacebookOperation.swift[0m
+INFO [2022-09-08 10:50:44.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CNPostalAddress.swift[0m
+INFO [2022-09-08 10:50:45.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsRoutePoints.swift[0m
+INFO [2022-09-08 10:50:45.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFetchedResultsAdapter.swift[0m
+INFO [2022-09-08 10:50:45.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUploadManager.swift[0m
+INFO [2022-09-08 10:50:45.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserProfileView.swift[0m
+INFO [2022-09-08 10:50:45.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Bootstrap.swift[0m
+INFO [2022-09-08 10:50:45.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDebugKit.swift[0m
+INFO [2022-09-08 10:50:45.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteSearchHistoryDataSource.swift[0m
+INFO [2022-09-08 10:50:45.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+Setup.swift[0m
+INFO [2022-09-08 10:50:45.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionStatsType.swift[0m
+INFO [2022-09-08 10:50:45.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOICommentTableViewCell.swift[0m
+INFO [2022-09-08 10:50:45.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteSourceFactory.swift[0m
+INFO [2022-09-08 10:50:45.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchBarView.swift[0m
+INFO [2022-09-08 10:50:45.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionDetailModel.swift[0m
+INFO [2022-09-08 10:50:45.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m URL.swift[0m
+INFO [2022-09-08 10:50:45.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteFiltering.swift[0m
+INFO [2022-09-08 10:50:45.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSocialShareView.swift[0m
+INFO [2022-09-08 10:50:45.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserProfileHostingViewController.swift[0m
+INFO [2022-09-08 10:50:45.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDesignableImageView.swift[0m
+INFO [2022-09-08 10:50:45.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSocialSignUpViewController.swift[0m
+INFO [2022-09-08 10:50:45.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMQAPopupAnalytics.swift[0m
+INFO [2022-09-08 10:50:45.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLayoutGalleryCellHeader.swift[0m
+INFO [2022-09-08 10:50:45.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBootstrapViewController.swift[0m
+INFO [2022-09-08 10:50:45.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsDetailViewController.swift[0m
+INFO [2022-09-08 10:50:45.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsCachesFolder.swift[0m
+INFO [2022-09-08 10:50:45.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMURLRequestProcessor.swift[0m
+INFO [2022-09-08 10:50:45.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionHelper.swift[0m
+INFO [2022-09-08 10:50:45.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionTableViewCell.swift[0m
+INFO [2022-09-08 10:50:45.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxMatchedRoute.swift[0m
+INFO [2022-09-08 10:50:45.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFetchUserOperation.swift[0m
+INFO [2022-09-08 10:50:45.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDirections.swift[0m
+INFO [2022-09-08 10:50:46.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideFinishStarView.swift[0m
+INFO [2022-09-08 10:50:46.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMActivityView+Shape.swift[0m
+INFO [2022-09-08 10:50:46.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteNavigationController.swift[0m
+INFO [2022-09-08 10:50:48.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GamificationService.swift[0m
+INFO [2022-09-08 10:50:48.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHistoryDataSource.swift[0m
+INFO [2022-09-08 10:50:48.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGroupActivityDirectionalArrowView.swift[0m
+INFO [2022-09-08 10:50:48.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPageControl.swift[0m
+INFO [2022-09-08 10:50:48.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTabViewController.swift[0m
+INFO [2022-09-08 10:50:48.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUpgradeSubscriptionViewController.swift[0m
+INFO [2022-09-08 10:50:48.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSiriShortcutManager.swift[0m
+INFO [2022-09-08 10:50:48.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteCollection+Bikemap.swift[0m
+INFO [2022-09-08 10:50:48.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBikeComputerOpenEvent.swift[0m
+INFO [2022-09-08 10:50:48.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsProperty.swift[0m
+INFO [2022-09-08 10:50:48.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HTTP+File.swift[0m
+INFO [2022-09-08 10:50:48.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NavigationResponseDecoder.swift[0m
+INFO [2022-09-08 10:50:48.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWaypointPin.swift[0m
+INFO [2022-09-08 10:50:48.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailsViewController+Present.swift[0m
+INFO [2022-09-08 10:50:48.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGroupActivityUserListView.swift[0m
+INFO [2022-09-08 10:50:48.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TransitionManager.swift[0m
+INFO [2022-09-08 10:50:48.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CodableUserDefault.swift[0m
+INFO [2022-09-08 10:50:48.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController.swift[0m
+INFO [2022-09-08 10:50:48.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBikeComputerSwitchStyleEvent.swift[0m
+INFO [2022-09-08 10:50:48.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMElevationProfileCallout.swift[0m
+INFO [2022-09-08 10:50:48.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTableViewModelProtocol.swift[0m
+INFO [2022-09-08 10:50:48.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailsARViewController.swift[0m
+INFO [2022-09-08 10:50:48.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NoSelectionBackgroundButtonStyle.swift[0m
+INFO [2022-09-08 10:50:48.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HTTP+Authentication.swift[0m
+INFO [2022-09-08 10:50:48.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMiniStatsView.swift[0m
+INFO [2022-09-08 10:50:48.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Gradient+Bikemap.swift[0m
+INFO [2022-09-08 10:50:49.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NumberSettingTableViewCell.swift[0m
+INFO [2022-09-08 10:50:49.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Preheatable.swift[0m
+INFO [2022-09-08 10:50:49.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ButtonSettingTableViewCell.swift[0m
+INFO [2022-09-08 10:50:49.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLayoutType.swift[0m
+INFO [2022-09-08 10:50:49.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIApplication+Bikemap.swift[0m
+INFO [2022-09-08 10:50:49.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CyclingPathsCustomModel.swift[0m
+INFO [2022-09-08 10:50:49.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PurchaseScreenHelper.swift[0m
+INFO [2022-09-08 10:50:49.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notification+Offline.swift[0m
+INFO [2022-09-08 10:50:49.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRemoteConfigManager.swift[0m
+INFO [2022-09-08 10:50:49.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTagsView.swift[0m
+INFO [2022-09-08 10:50:49.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSharedLocationBottomSheetViewController.swift[0m
+INFO [2022-09-08 10:50:49.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession+Subscription.swift[0m
+INFO [2022-09-08 10:50:49.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PushNotificationSettingsStore.swift[0m
+INFO [2022-09-08 10:50:49.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigateRequest.swift[0m
+INFO [2022-09-08 10:50:49.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsSubscription.swift[0m
+INFO [2022-09-08 10:50:49.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIImageView+Bikemap.swift[0m
+INFO [2022-09-08 10:50:49.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerView.swift[0m
+INFO [2022-09-08 10:50:49.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSetHomeWorkViewController.swift[0m
+INFO [2022-09-08 10:50:49.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSupportEmailController.swift[0m
+INFO [2022-09-08 10:50:49.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGraphHopper.swift[0m
+INFO [2022-09-08 10:50:49.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Address.swift[0m
+INFO [2022-09-08 10:50:49.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m User+Triggers.swift[0m
+INFO [2022-09-08 10:50:49.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionRow.swift[0m
+INFO [2022-09-08 10:50:49.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession+Authentication.swift[0m
+INFO [2022-09-08 10:50:49.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsTermination.swift[0m
+INFO [2022-09-08 10:50:49.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionDetailView.swift[0m
+INFO [2022-09-08 10:50:49.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBikeComputerAutoCloseEvent.swift[0m
+INFO [2022-09-08 10:50:49.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionDescriptionView.swift[0m
+INFO [2022-09-08 10:50:49.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapStyleCell.swift[0m
+INFO [2022-09-08 10:50:49.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDeeplink.swift[0m
+INFO [2022-09-08 10:50:50.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUploadTaskFactory.swift[0m
+INFO [2022-09-08 10:50:50.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProximaNovaFont.swift[0m
+INFO [2022-09-08 10:50:50.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMStarView.swift[0m
+INFO [2022-09-08 10:50:50.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMergeSocialAccountViewController.swift[0m
+INFO [2022-09-08 10:50:50.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationPossibleChecker.swift[0m
+INFO [2022-09-08 10:50:50.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineRegionStore.swift[0m
+INFO [2022-09-08 10:50:50.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PointsEarnedDotView.swift[0m
+INFO [2022-09-08 10:50:50.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:50:50.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ScaledFont.swift[0m
+INFO [2022-09-08 10:50:50.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLayoutGalleryCell.swift[0m
+INFO [2022-09-08 10:50:50.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUITestAnalyticsEventData.swift[0m
+INFO [2022-09-08 10:50:50.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StreakActivityStore.swift[0m
+INFO [2022-09-08 10:50:50.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SocialMediaProvider.swift[0m
+INFO [2022-09-08 10:50:50.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecordingSyncStore.swift[0m
+INFO [2022-09-08 10:50:50.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDebugAnnotation.swift[0m
+INFO [2022-09-08 10:50:50.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Formatter+Bikemap.swift[0m
+INFO [2022-09-08 10:50:50.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteUploadViewController+Photo.swift[0m
+INFO [2022-09-08 10:50:50.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsCrash.swift[0m
+INFO [2022-09-08 10:50:50.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMShareViewStore.swift[0m
+INFO [2022-09-08 10:50:50.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PremiumLoopView.swift[0m
+INFO [2022-09-08 10:50:50.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhotoCollectionViewCell.swift[0m
+INFO [2022-09-08 10:50:50.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNotification.swift[0m
+INFO [2022-09-08 10:50:50.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLPointFeature+Bikemap.swift[0m
+INFO [2022-09-08 10:50:50.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLOfflinePack+Bikemap.swift[0m
+INFO [2022-09-08 10:50:50.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Double+BMTimeFormatter.swift[0m
+INFO [2022-09-08 10:50:50.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession.swift[0m
+INFO [2022-09-08 10:50:50.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLPolylineOverlay.swift[0m
+INFO [2022-09-08 10:50:50.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PulleyViewController+Bikemap.swift[0m
+INFO [2022-09-08 10:50:50.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapHeadingStates.swift[0m
+INFO [2022-09-08 10:50:50.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FallDetectionAlarmView.swift[0m
+INFO [2022-09-08 10:50:50.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWelcomeViewController.swift[0m
+INFO [2022-09-08 10:50:50.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMKeepSubscribersViewController.swift[0m
+INFO [2022-09-08 10:50:50.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTrialTracker.swift[0m
+INFO [2022-09-08 10:50:50.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserProfileImageView.swift[0m
+INFO [2022-09-08 10:50:51.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notification+Login.swift[0m
+INFO [2022-09-08 10:50:51.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerActivityRingsElementView.swift[0m
+INFO [2022-09-08 10:50:51.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPaginator.swift[0m
+INFO [2022-09-08 10:50:51.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMViewModelProtocol.swift[0m
+INFO [2022-09-08 10:50:51.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+POI.swift[0m
+INFO [2022-09-08 10:50:51.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerStoreProtocol.swift[0m
+INFO [2022-09-08 10:50:51.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StreakModel.swift[0m
+INFO [2022-09-08 10:50:51.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteUpload+Bikemap.swift[0m
+INFO [2022-09-08 10:50:51.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOIBottomSheetViewController.swift[0m
+INFO [2022-09-08 10:50:51.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationService.swift[0m
+INFO [2022-09-08 10:50:51.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DrawablePolygon.swift[0m
+INFO [2022-09-08 10:50:51.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchResultsViewController.swift[0m
+INFO [2022-09-08 10:50:51.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGenericTableViewDataSource.swift[0m
+INFO [2022-09-08 10:50:51.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m EnumUserDefault.swift[0m
+INFO [2022-09-08 10:50:51.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFirebaseDynamicLinkAPI.swift[0m
+INFO [2022-09-08 10:50:51.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SharedUserDefaultsKeys.swift[0m
+INFO [2022-09-08 10:50:51.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMyActivityTitleLabel.swift[0m
+INFO [2022-09-08 10:50:51.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsABVariant.swift[0m
+INFO [2022-09-08 10:50:51.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhoneSettingsPayload.swift[0m
+INFO [2022-09-08 10:50:51.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAsyncOperation.swift[0m
+INFO [2022-09-08 10:50:51.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PurchaseScreenViewHostingController.swift[0m
+INFO [2022-09-08 10:50:51.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineNavigationFilesResponse.swift[0m
+INFO [2022-09-08 10:50:51.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Geometry.swift[0m
+INFO [2022-09-08 10:50:51.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMEmptyStateViewController.swift[0m
+INFO [2022-09-08 10:50:51.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigateIntent.swift[0m
+INFO [2022-09-08 10:50:51.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Comment+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:51.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Comment+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:51.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Feed+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:51.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Feed+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:51.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Map+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:51.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDiscoverAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:50:51.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAuthProvider.swift[0m
+INFO [2022-09-08 10:50:51.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPasswordGeneratorNotificationView.swift[0m
+INFO [2022-09-08 10:50:52.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMEditButton.swift[0m
+INFO [2022-09-08 10:50:52.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSharedLocationAnnotation.swift[0m
+INFO [2022-09-08 10:50:52.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m log.swift[0m
+INFO [2022-09-08 10:50:52.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Stack.swift[0m
+INFO [2022-09-08 10:50:52.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLoadingIndicatorButton.swift[0m
+INFO [2022-09-08 10:50:52.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPulleyContentController.swift[0m
+INFO [2022-09-08 10:50:52.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CustomizeLayoutButton.swift[0m
+INFO [2022-09-08 10:50:52.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MyRoutesStore.swift[0m
+INFO [2022-09-08 10:50:52.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMElevationChartView.swift[0m
+INFO [2022-09-08 10:50:52.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSnapshotViewLayers.swift[0m
+INFO [2022-09-08 10:50:52.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigateIntentHandler.swift[0m
+INFO [2022-09-08 10:50:52.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOICategoriesViewController.swift[0m
+INFO [2022-09-08 10:50:52.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMForgotUserOrPassViewController.swift[0m
+INFO [2022-09-08 10:50:52.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MedicalIDTutorialView.swift[0m
+INFO [2022-09-08 10:50:52.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Feed+Bikemap.swift[0m
+INFO [2022-09-08 10:50:52.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AppDelegate+Bikemap.swift[0m
+INFO [2022-09-08 10:50:52.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPaddedButton.swift[0m
+INFO [2022-09-08 10:50:52.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerStartRecordingButton.swift[0m
+INFO [2022-09-08 10:50:52.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserAvatarView.swift[0m
+INFO [2022-09-08 10:50:52.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDirectionsProvider.swift[0m
+INFO [2022-09-08 10:50:52.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteNavigationSettingsViewController+Map.swift[0m
+INFO [2022-09-08 10:50:52.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SafariView.swift[0m
+INFO [2022-09-08 10:50:52.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerHeaderView.swift[0m
+INFO [2022-09-08 10:50:52.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePOI.swift[0m
+INFO [2022-09-08 10:50:52.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AppDelegate+AppExtentions.swift[0m
+INFO [2022-09-08 10:50:52.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsAppVersion.swift[0m
+INFO [2022-09-08 10:50:52.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNetworkManager.swift[0m
+INFO [2022-09-08 10:50:52.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPlannedRoutesViewController.swift[0m
+INFO [2022-09-08 10:50:52.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPolygonCalculator.swift[0m
+INFO [2022-09-08 10:50:52.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLayout.swift[0m
+INFO [2022-09-08 10:50:52.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIView+Bikemap.swift[0m
+INFO [2022-09-08 10:50:53.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCreateNewRouteCollectionRow.swift[0m
+INFO [2022-09-08 10:50:53.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapSettingsViewController.swift[0m
+INFO [2022-09-08 10:50:53.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSENavigationViewController+POI.swift[0m
+INFO [2022-09-08 10:50:53.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGPXRoute.swift[0m
+INFO [2022-09-08 10:50:53.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchParameters.swift[0m
+INFO [2022-09-08 10:50:53.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionAboutView.swift[0m
+INFO [2022-09-08 10:50:53.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideFinishFeedbackView.swift[0m
+INFO [2022-09-08 10:50:53.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLocationStore.swift[0m
+INFO [2022-09-08 10:50:53.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutingFileStatusCheck.swift[0m
+INFO [2022-09-08 10:50:53.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerProgressBackgroundView.swift[0m
+INFO [2022-09-08 10:50:53.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GradientProgressViewStyle.swift[0m
+INFO [2022-09-08 10:50:53.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsNotificationThreshold.swift[0m
+INFO [2022-09-08 10:50:53.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsRecordMode.swift[0m
+INFO [2022-09-08 10:50:53.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLayoutGalleryView.swift[0m
+INFO [2022-09-08 10:50:53.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoute.swift[0m
+INFO [2022-09-08 10:50:53.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMInputPasswordViewController.swift[0m
+INFO [2022-09-08 10:50:54.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchFilterViewController.swift[0m
+INFO [2022-09-08 10:50:54.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMReportsController.swift[0m
+INFO [2022-09-08 10:50:54.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AppDelegate+Notifications.swift[0m
+INFO [2022-09-08 10:50:54.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapHeadingStateMachine.swift[0m
+INFO [2022-09-08 10:50:54.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MedicalIDTutorialNavigationControllerView.swift[0m
+INFO [2022-09-08 10:50:54.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PhotoUpload+Bikemap.swift[0m
+INFO [2022-09-08 10:50:54.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m DistanceUnitsView.swift[0m
+INFO [2022-09-08 10:50:54.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBikeComputerCloseEvent.swift[0m
+INFO [2022-09-08 10:50:54.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LightDarkHostingViewController.swift[0m
+INFO [2022-09-08 10:50:54.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMProgressNotificationPageView.swift[0m
+INFO [2022-09-08 10:50:54.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerPlaceholderLocationStore.swift[0m
+INFO [2022-09-08 10:50:54.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Optional.swift[0m
+INFO [2022-09-08 10:50:54.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserListOperation.swift[0m
+INFO [2022-09-08 10:50:54.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIColor+Bikemap.swift[0m
+INFO [2022-09-08 10:50:54.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StreakActivity.swift[0m
+INFO [2022-09-08 10:50:54.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchViewController.swift[0m
+INFO [2022-09-08 10:50:54.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession+Connectivity.swift[0m
+INFO [2022-09-08 10:50:54.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePOIPin.swift[0m
+INFO [2022-09-08 10:50:54.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSupportedLinks.swift[0m
+INFO [2022-09-08 10:50:54.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWorkoutStatisticPayload.swift[0m
+INFO [2022-09-08 10:50:54.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPaddedLabel.swift[0m
+INFO [2022-09-08 10:50:54.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserMatch.swift[0m
+INFO [2022-09-08 10:50:54.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationPauseBottomSheetViewController.swift[0m
+INFO [2022-09-08 10:50:54.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMButtonsNotificationView.swift[0m
+INFO [2022-09-08 10:50:55.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPremiumTrigger.swift[0m
+INFO [2022-09-08 10:50:55.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m FriendReferralPopupViewController.swift[0m
+INFO [2022-09-08 10:50:55.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerFooterButton.swift[0m
+INFO [2022-09-08 10:50:55.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLMapView+SafeCenter.swift[0m
+INFO [2022-09-08 10:50:55.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StreakActivityDay.swift[0m
+INFO [2022-09-08 10:50:55.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m User+Premium.swift[0m
+INFO [2022-09-08 10:50:55.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLayoutV2.swift[0m
+INFO [2022-09-08 10:50:55.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhotoGalleryView.swift[0m
+INFO [2022-09-08 10:50:55.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBasicEventType.swift[0m
+INFO [2022-09-08 10:50:55.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSharedLocationPin.swift[0m
+INFO [2022-09-08 10:50:55.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UniqueRouteMapping.swift[0m
+INFO [2022-09-08 10:50:55.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGroupActivityAvatars.swift[0m
+INFO [2022-09-08 10:50:55.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationSearchHistoryDataSource.swift[0m
+INFO [2022-09-08 10:50:55.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNetworkResponse.swift[0m
+INFO [2022-09-08 10:50:55.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m User+Purchase.swift[0m
+INFO [2022-09-08 10:50:55.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AutoLockManager.swift[0m
+INFO [2022-09-08 10:50:55.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PurchaseScreenView.swift[0m
+INFO [2022-09-08 10:50:55.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSignUpAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:50:55.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StreakActivityView.swift[0m
+INFO [2022-09-08 10:50:55.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMProgressNotificationView.swift[0m
+INFO [2022-09-08 10:50:55.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RemoteImage.swift[0m
+INFO [2022-09-08 10:50:55.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:50:55.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GlobalStats.swift[0m
+INFO [2022-09-08 10:50:55.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionTitleSection.swift[0m
+INFO [2022-09-08 10:50:55.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionSelectionViewModel.swift[0m
+INFO [2022-09-08 10:50:55.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GradientView.swift[0m
+INFO [2022-09-08 10:50:55.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationWarnings.swift[0m
+INFO [2022-09-08 10:50:55.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteCollection+API.swift[0m
+INFO [2022-09-08 10:50:55.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionSelectionViewController.swift[0m
+INFO [2022-09-08 10:50:55.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLayoutGalleryViewController.swift[0m
+INFO [2022-09-08 10:50:55.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIVisualEffectView+Bikemap.swift[0m
+INFO [2022-09-08 10:50:55.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGeocoder.swift[0m
+INFO [2022-09-08 10:50:56.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route+NSUserActivity.swift[0m
+INFO [2022-09-08 10:50:56.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Data+Bikemap.swift[0m
+INFO [2022-09-08 10:50:56.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRoutesViewController.swift[0m
+INFO [2022-09-08 10:50:56.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ActivityIndicator.swift[0m
+INFO [2022-09-08 10:50:56.10]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideFinishStore.swift[0m
+INFO [2022-09-08 10:50:56.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNetworkMonitor.swift[0m
+INFO [2022-09-08 10:50:56.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGeoJsonConvertible.swift[0m
+INFO [2022-09-08 10:50:56.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BadgedUserImage.swift[0m
+INFO [2022-09-08 10:50:56.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionViewController.swift[0m
+INFO [2022-09-08 10:50:56.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMShareService.swift[0m
+INFO [2022-09-08 10:50:56.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PushNotificationSettingsResponseAPIModel.swift[0m
+INFO [2022-09-08 10:50:56.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGradientView.swift[0m
+INFO [2022-09-08 10:50:56.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Comment+Bikemap.swift[0m
+INFO [2022-09-08 10:50:56.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Date+Bikemap.swift[0m
+INFO [2022-09-08 10:50:56.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMEmailSignUpViewController.swift[0m
+INFO [2022-09-08 10:50:56.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDeletablePhotoCollectionViewCell.swift[0m
+INFO [2022-09-08 10:50:56.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePlannerBottomSheetViewController.swift[0m
+INFO [2022-09-08 10:50:56.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LargeRoundedRectangleButton.swift[0m
+INFO [2022-09-08 10:50:56.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideFinishView.swift[0m
+INFO [2022-09-08 10:50:56.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMyActivityAPI.swift[0m
+INFO [2022-09-08 10:50:56.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionTableViewCell.swift[0m
+INFO [2022-09-08 10:50:56.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserRegistrationOperation.swift[0m
+INFO [2022-09-08 10:50:56.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m User+Authentication.swift[0m
+INFO [2022-09-08 10:50:56.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserProgress.swift[0m
+INFO [2022-09-08 10:50:56.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFullscreenMapViewController.swift[0m
+INFO [2022-09-08 10:50:56.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SegmentSettingTableViewCell.swift[0m
+INFO [2022-09-08 10:50:56.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionView.swift[0m
+INFO [2022-09-08 10:50:56.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AnyOptional.swift[0m
+INFO [2022-09-08 10:50:56.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLabelWithCopy.swift[0m
+INFO [2022-09-08 10:50:56.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOICommentsViewController.swift[0m
+INFO [2022-09-08 10:50:56.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNotificationCenter+Bikemap.swift[0m
+INFO [2022-09-08 10:50:56.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUITestAnalytics.swift[0m
+INFO [2022-09-08 10:50:56.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m POIUpload+Bikemap.swift[0m
+INFO [2022-09-08 10:50:56.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMVoiceInstruction.swift[0m
+INFO [2022-09-08 10:50:57.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIAlertController+Bikemap.swift[0m
+INFO [2022-09-08 10:50:57.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailViewModel.swift[0m
+INFO [2022-09-08 10:50:57.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LinearInterpolation.swift[0m
+INFO [2022-09-08 10:50:57.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AppDefaults.swift[0m
+INFO [2022-09-08 10:50:57.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikemapService.swift[0m
+INFO [2022-09-08 10:50:57.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Map+Bikemap.swift[0m
+INFO [2022-09-08 10:50:57.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePOICalloutView.swift[0m
+INFO [2022-09-08 10:50:57.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Map+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineRegion+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineRegion+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineRoutingFile+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineRoutingFile+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineTilePack+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineTilePack+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PhotoUpload+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PhotoUpload+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.49]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m POI+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m POI+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m POIUpload+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m POIUpload+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteCollection+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteCollection+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteImage+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteImage+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteSearchResult+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteSearchResult+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteUpload+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteUpload+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m User+CoreDataClass.swift[0m
+INFO [2022-09-08 10:50:57.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m User+CoreDataProperties.swift[0m
+INFO [2022-09-08 10:50:57.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Bikemap+CoreDataModel.swift[0m
+INFO [2022-09-08 10:50:58.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BoolSettingTableViewCell.swift[0m
+INFO [2022-09-08 10:50:58.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+Handlers.swift[0m
+INFO [2022-09-08 10:50:58.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolygonUnifier.swift[0m
+INFO [2022-09-08 10:50:58.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteCollectionService.swift[0m
+INFO [2022-09-08 10:50:58.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMReportBottomSheetViewController.swift[0m
+INFO [2022-09-08 10:50:58.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapStyleAPI.swift[0m
+INFO [2022-09-08 10:50:58.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionDownloader.swift[0m
+INFO [2022-09-08 10:50:58.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TextStyle.swift[0m
+INFO [2022-09-08 10:50:58.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteAnnotation.swift[0m
+INFO [2022-09-08 10:50:58.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationMapStyleDay.swift[0m
+INFO [2022-09-08 10:50:58.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsFirebaseID.swift[0m
+INFO [2022-09-08 10:50:58.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AppDelegate+HomeScreenQuickActions.swift[0m
+INFO [2022-09-08 10:50:58.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineMapParameters.swift[0m
+INFO [2022-09-08 10:50:58.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWatchMessagePayloadProtocol.swift[0m
+INFO [2022-09-08 10:50:58.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MockRouteCollectionService.swift[0m
+INFO [2022-09-08 10:50:58.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAuthorizationAppleIDManager.swift[0m
+INFO [2022-09-08 10:50:58.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationViewController.swift[0m
+INFO [2022-09-08 10:50:58.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTilePackDownloader.swift[0m
+INFO [2022-09-08 10:50:58.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationStartBottomSheetViewController.swift[0m
+INFO [2022-09-08 10:50:58.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOICategory.swift[0m
+INFO [2022-09-08 10:50:58.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTextInputCompatibleViewController.swift[0m
+INFO [2022-09-08 10:50:58.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFilteringBarViewController.swift[0m
+INFO [2022-09-08 10:50:58.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionRowImage.swift[0m
+INFO [2022-09-08 10:50:58.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CALayer+Bikemap.swift[0m
+INFO [2022-09-08 10:50:58.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapDarkModeSetting.swift[0m
+INFO [2022-09-08 10:50:58.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAccessTokenRequest.swift[0m
+INFO [2022-09-08 10:50:58.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLMapView+DrawPolygon.swift[0m
+INFO [2022-09-08 10:50:58.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSwitch.swift[0m
+INFO [2022-09-08 10:50:58.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UILabel+Bikemap.swift[0m
+INFO [2022-09-08 10:50:58.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapboxNavigationExtensions.swift[0m
+INFO [2022-09-08 10:50:59.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SKProduct+Bikemap.swift[0m
+INFO [2022-09-08 10:50:59.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMachineLearningQAView.swift[0m
+INFO [2022-09-08 10:50:59.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTurfHelper.swift[0m
+INFO [2022-09-08 10:50:59.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSocialShareButtons.swift[0m
+INFO [2022-09-08 10:50:59.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOIService.swift[0m
+INFO [2022-09-08 10:50:59.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsShowEventLabels.swift[0m
+INFO [2022-09-08 10:50:59.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCredentials.swift[0m
+INFO [2022-09-08 10:50:59.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsService.swift[0m
+INFO [2022-09-08 10:50:59.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SizingView.swift[0m
+INFO [2022-09-08 10:50:59.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Int+Mod.swift[0m
+INFO [2022-09-08 10:50:59.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m User+Bikemap.swift[0m
+INFO [2022-09-08 10:50:59.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationTopBannerView.swift[0m
+INFO [2022-09-08 10:50:59.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAppleSignInOperation.swift[0m
+INFO [2022-09-08 10:50:59.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMProfileHeaderView.swift[0m
+INFO [2022-09-08 10:50:59.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserProfileStore.swift[0m
+INFO [2022-09-08 10:50:59.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMKeyboardCompatibleViewController.swift[0m
+INFO [2022-09-08 10:50:59.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationInstructionTableViewCell.swift[0m
+INFO [2022-09-08 10:50:59.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLayoutStore.swift[0m
+INFO [2022-09-08 10:50:59.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideFinishStatisticView.swift[0m
+INFO [2022-09-08 10:50:59.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route+API.swift[0m
+INFO [2022-09-08 10:50:59.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Bikemap_vers.c[0m
+INFO [2022-09-08 10:50:59.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRefreshTokenOperation.swift[0m
+INFO [2022-09-08 10:50:59.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePOIManager.swift[0m
+INFO [2022-09-08 10:50:59.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserProgressStore.swift[0m
+INFO [2022-09-08 10:50:59.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProfileImageView.swift[0m
+INFO [2022-09-08 10:50:59.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionViewModel.swift[0m
+INFO [2022-09-08 10:50:59.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsBasicEventPayload.swift[0m
+INFO [2022-09-08 10:50:59.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePOIAnnotation.swift[0m
+INFO [2022-09-08 10:50:59.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLaunchArguments.swift[0m
+INFO [2022-09-08 10:51:00.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMReferAFriendView.swift[0m
+INFO [2022-09-08 10:51:00.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHistoryItem+FetchAddress.swift[0m
+INFO [2022-09-08 10:51:00.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSManagedObject+Bikemap.swift[0m
+INFO [2022-09-08 10:51:00.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMStoredRoutesViewController.swift[0m
+INFO [2022-09-08 10:51:00.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Triangle.swift[0m
+INFO [2022-09-08 10:51:00.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDirectionsService.swift[0m
+INFO [2022-09-08 10:51:00.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:51:00.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerChartView.swift[0m
+INFO [2022-09-08 10:51:00.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteCollectionServiceProtocol.swift[0m
+INFO [2022-09-08 10:51:00.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserLoginOperation.swift[0m
+INFO [2022-09-08 10:51:00.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGoogleOperation.swift[0m
+INFO [2022-09-08 10:51:00.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePOIBSViewController.swift[0m
+INFO [2022-09-08 10:51:00.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOICategoryDetailViewController.swift[0m
+INFO [2022-09-08 10:51:00.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteNavigationSettings.swift[0m
+INFO [2022-09-08 10:51:00.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ShareSheet.swift[0m
+INFO [2022-09-08 10:51:00.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m String+Bikemap.swift[0m
+INFO [2022-09-08 10:51:00.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailsViewController+Siri.swift[0m
+INFO [2022-09-08 10:51:00.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMProgressNotificationViewModel.swift[0m
+INFO [2022-09-08 10:51:00.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m StreakConnectorImage.swift[0m
+INFO [2022-09-08 10:51:00.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionsListViewController.swift[0m
+INFO [2022-09-08 10:51:00.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSnappingFlowLayout.swift[0m
+INFO [2022-09-08 10:51:00.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteCollectionViewCell.swift[0m
+INFO [2022-09-08 10:51:00.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDeepLinks.swift[0m
+INFO [2022-09-08 10:51:00.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerElementType+ContextMenu.swift[0m
+INFO [2022-09-08 10:51:00.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhoneConnectivityManager.swift[0m
+INFO [2022-09-08 10:51:00.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationTopBannerViewController.swift[0m
+INFO [2022-09-08 10:51:00.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalytics.swift[0m
+INFO [2022-09-08 10:51:00.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserNotifications.swift[0m
+INFO [2022-09-08 10:51:00.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMURLSessionManager.swift[0m
+INFO [2022-09-08 10:51:00.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMissingNumberFinder.swift[0m
+INFO [2022-09-08 10:51:01.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMStreaksHeaderView.swift[0m
+INFO [2022-09-08 10:51:01.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UITabBar+Bikemap.swift[0m
+INFO [2022-09-08 10:51:01.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFacebookAnalytics.swift[0m
+INFO [2022-09-08 10:51:01.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PageControl.swift[0m
+INFO [2022-09-08 10:51:01.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRetentionTriggerType.swift[0m
+INFO [2022-09-08 10:51:01.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNotificationAction+Ride.swift[0m
+INFO [2022-09-08 10:51:01.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNotificationAction.swift[0m
+INFO [2022-09-08 10:51:01.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAboutViewController.swift[0m
+INFO [2022-09-08 10:51:01.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route+Polygon.swift[0m
+INFO [2022-09-08 10:51:01.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route+Offline.swift[0m
+INFO [2022-09-08 10:51:01.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapSettingsOfflineMapsUpsellCell.swift[0m
+INFO [2022-09-08 10:51:01.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPurchaseParameters.swift[0m
+INFO [2022-09-08 10:51:04.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIImage+Bikemap.swift[0m
+INFO [2022-09-08 10:51:04.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NSLayoutConstraint+Bikemap.swift[0m
+INFO [2022-09-08 10:51:04.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMProfileHeader.swift[0m
+INFO [2022-09-08 10:51:04.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMReloadable.swift[0m
+INFO [2022-09-08 10:51:04.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPromotionalOfferSign.swift[0m
+INFO [2022-09-08 10:51:04.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHistoryItem.swift[0m
+INFO [2022-09-08 10:51:04.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGroupActivityPin.swift[0m
+INFO [2022-09-08 10:51:04.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideWaypointCell.swift[0m
+INFO [2022-09-08 10:51:04.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionError.swift[0m
+INFO [2022-09-08 10:51:04.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TabTooltipView.swift[0m
+INFO [2022-09-08 10:51:04.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteNavigationSettingsViewController.swift[0m
+INFO [2022-09-08 10:51:04.42]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager+Support.swift[0m
+INFO [2022-09-08 10:51:04.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProcessInfo+UITest.swift[0m
+INFO [2022-09-08 10:51:04.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PurchaseScreenProtocol.swift[0m
+INFO [2022-09-08 10:51:04.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerActivityRingsSwiftUIView.swift[0m
+INFO [2022-09-08 10:51:04.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HTTPURLResponse+Status.swift[0m
+INFO [2022-09-08 10:51:04.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationFeedbackOptions.swift[0m
+INFO [2022-09-08 10:51:04.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CollectionImageView.swift[0m
+INFO [2022-09-08 10:51:04.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MapKit+Bikemap.swift[0m
+INFO [2022-09-08 10:51:04.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Double+Bikemap.swift[0m
+INFO [2022-09-08 10:51:04.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteMapViewController.swift[0m
+INFO [2022-09-08 10:51:04.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RDPPolylineSimplifier.swift[0m
+INFO [2022-09-08 10:51:04.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideData.swift[0m
+INFO [2022-09-08 10:51:04.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTagCollectionViewCell.swift[0m
+INFO [2022-09-08 10:51:04.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDottedArrowView.swift[0m
+INFO [2022-09-08 10:51:04.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsViewController.swift[0m
+INFO [2022-09-08 10:51:04.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIScrollView+Bikemap.swift[0m
+INFO [2022-09-08 10:51:04.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBottomSheetContentViewController.swift[0m
+INFO [2022-09-08 10:51:04.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapboxDirectionsEmulator+GraphHopper.swift[0m
+INFO [2022-09-08 10:51:04.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDesignableView.swift[0m
+INFO [2022-09-08 10:51:04.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecordedRoutesViewController.swift[0m
+INFO [2022-09-08 10:51:04.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ActivityView.swift[0m
+INFO [2022-09-08 10:51:04.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m InfoSettingTableViewCell.swift[0m
+INFO [2022-09-08 10:51:04.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProcessInfo+Bikemap.swift[0m
+INFO [2022-09-08 10:51:04.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPaddedGradientButton.swift[0m
+INFO [2022-09-08 10:51:05.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRemoteConfiguration.swift[0m
+INFO [2022-09-08 10:51:05.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAbstractSignUpViewController.swift[0m
+INFO [2022-09-08 10:51:05.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideFinishFeedbackStore.swift[0m
+INFO [2022-09-08 10:51:05.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+ShareLocation.swift[0m
+INFO [2022-09-08 10:51:05.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IndexPath+Bikemap.swift[0m
+INFO [2022-09-08 10:51:05.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRegistrationUserMatch.swift[0m
+INFO [2022-09-08 10:51:05.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CGFloat+Bikemap.swift[0m
+INFO [2022-09-08 10:51:05.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsProtocols.swift[0m
+INFO [2022-09-08 10:51:05.20]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m TagListViewRepresentable.swift[0m
+INFO [2022-09-08 10:51:05.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWaypointAnnotation.swift[0m
+INFO [2022-09-08 10:51:05.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationDeeplink.swift[0m
+INFO [2022-09-08 10:51:05.27]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPremiumTriggerType.swift[0m
+INFO [2022-09-08 10:51:05.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsInvalidateAccessToken.swift[0m
+INFO [2022-09-08 10:51:05.32]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PurchaseScreenYearlyButton.swift[0m
+INFO [2022-09-08 10:51:05.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsInvalidateRefreshToken.swift[0m
+INFO [2022-09-08 10:51:05.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSharedRidePayload.swift[0m
+INFO [2022-09-08 10:51:05.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RoutePOI+API.swift[0m
+INFO [2022-09-08 10:51:05.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhoneAppStatePayload.swift[0m
+INFO [2022-09-08 10:51:05.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutingFileRequestor.swift[0m
+INFO [2022-09-08 10:51:05.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOI.swift[0m
+INFO [2022-09-08 10:51:05.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NotificationStreakView.swift[0m
+INFO [2022-09-08 10:51:05.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRangeSeekSlider.swift[0m
+INFO [2022-09-08 10:51:05.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutingProfile.swift[0m
+INFO [2022-09-08 10:51:05.55]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGroupActivityUser.swift[0m
+INFO [2022-09-08 10:51:05.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RideStatisticsView.swift[0m
+INFO [2022-09-08 10:51:05.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDownloadableRoutesViewController.swift[0m
+INFO [2022-09-08 10:51:05.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession+Trigger.swift[0m
+INFO [2022-09-08 10:51:05.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerSharePlayButton.swift[0m
+INFO [2022-09-08 10:51:05.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUploadedRoutePhoto.swift[0m
+INFO [2022-09-08 10:51:05.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRegionCroppingView.swift[0m
+INFO [2022-09-08 10:51:05.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPostPoiCommentRequest.swift[0m
+INFO [2022-09-08 10:51:05.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchBottomSheetViewController.swift[0m
+INFO [2022-09-08 10:51:05.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSharedPOIAnnotation.swift[0m
+INFO [2022-09-08 10:51:05.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRoutingUpdater.swift[0m
+INFO [2022-09-08 10:51:05.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMExpandableAnnotation.swift[0m
+INFO [2022-09-08 10:51:05.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m HTTP.swift[0m
+INFO [2022-09-08 10:51:05.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RegularButtonStyle.swift[0m
+INFO [2022-09-08 10:51:05.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m OfflineRoutingFile+Bikemap.swift[0m
+INFO [2022-09-08 10:51:05.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationStateHolder.swift[0m
+INFO [2022-09-08 10:51:05.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideGroupActivity.swift[0m
+INFO [2022-09-08 10:51:05.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+MapDecorations.swift[0m
+INFO [2022-09-08 10:51:05.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUserProfileOfflineView.swift[0m
+INFO [2022-09-08 10:51:06.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerChartSwiftUIView.swift[0m
+INFO [2022-09-08 10:51:06.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsRemoveAccessToken.swift[0m
+INFO [2022-09-08 10:51:06.05]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMyActivityFooterView.swift[0m
+INFO [2022-09-08 10:51:06.07]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RideStatisticsPlaceholderViewHostingController.swift[0m
+INFO [2022-09-08 10:51:06.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerLocationStoreProtocol.swift[0m
+INFO [2022-09-08 10:51:06.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsFirebaseConfiguration.swift[0m
+INFO [2022-09-08 10:51:06.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BinaryInteger+Bikemap.swift[0m
+INFO [2022-09-08 10:51:06.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRecordingDidChangePayload.swift[0m
+INFO [2022-09-08 10:51:06.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerEndRecordingButton.swift[0m
+INFO [2022-09-08 10:51:06.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m GlobalStatsInteractor.swift[0m
+INFO [2022-09-08 10:51:06.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PurchaseScreenMonthlyButton.swift[0m
+INFO [2022-09-08 10:51:06.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationManager.swift[0m
+INFO [2022-09-08 10:51:06.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionSelectionView.swift[0m
+INFO [2022-09-08 10:51:06.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NotificationToken.swift[0m
+INFO [2022-09-08 10:51:06.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m POI+Bikemap.swift[0m
+INFO [2022-09-08 10:51:06.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineMapSetting.swift[0m
+INFO [2022-09-08 10:51:06.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSubscription.swift[0m
+INFO [2022-09-08 10:51:06.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteIntentHandler.swift[0m
+INFO [2022-09-08 10:51:06.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutingFileDownloader.swift[0m
+INFO [2022-09-08 10:51:06.45]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTapticFeedbackGenerator.swift[0m
+INFO [2022-09-08 10:51:06.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMActionButton.swift[0m
+INFO [2022-09-08 10:51:06.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikemapDirections.swift[0m
+INFO [2022-09-08 10:51:06.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMProducts.swift[0m
+INFO [2022-09-08 10:51:06.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionDetailsViewController.swift[0m
+INFO [2022-09-08 10:51:06.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHeaderView.swift[0m
+INFO [2022-09-08 10:51:06.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsShowAdAttribution.swift[0m
+INFO [2022-09-08 10:51:06.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionSizeCalculator.swift[0m
+INFO [2022-09-08 10:51:06.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AdaptiveSheet.swift[0m
+INFO [2022-09-08 10:51:06.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSecureStorage.swift[0m
+INFO [2022-09-08 10:51:06.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteStyleCell.swift[0m
+INFO [2022-09-08 10:51:06.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route+Displayable.swift[0m
+INFO [2022-09-08 10:51:06.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBikeComputerActivateForthRowEvent.swift[0m
+INFO [2022-09-08 10:51:06.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Route+Map.swift[0m
+INFO [2022-09-08 10:51:06.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsRequestNotificationAuthorization.swift[0m
+INFO [2022-09-08 10:51:06.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UITextViewRepresentable.swift[0m
+INFO [2022-09-08 10:51:06.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserDefault.swift[0m
+INFO [2022-09-08 10:51:06.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapMatchingService.swift[0m
+INFO [2022-09-08 10:51:06.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTintedLoadingIndicatorButton.swift[0m
+INFO [2022-09-08 10:51:06.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideFinishStatisticPropertyView.swift[0m
+INFO [2022-09-08 10:51:06.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineMapConformable.swift[0m
+INFO [2022-09-08 10:51:06.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserDefaults.swift[0m
+INFO [2022-09-08 10:51:06.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRetryPurchaseManager.swift[0m
+INFO [2022-09-08 10:51:06.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAbstractPurchaseViewController.swift[0m
+INFO [2022-09-08 10:51:07.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsEvent.swift[0m
+INFO [2022-09-08 10:51:07.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteStep.swift[0m
+INFO [2022-09-08 10:51:07.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhotoCarouselView.swift[0m
+INFO [2022-09-08 10:51:07.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Fonts.swift[0m
+INFO [2022-09-08 10:51:07.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Array+gpx.swift[0m
+INFO [2022-09-08 10:51:07.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationMapStyleNight.swift[0m
+INFO [2022-09-08 10:51:07.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWayPoint.swift[0m
+INFO [2022-09-08 10:51:07.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationProgressBottomSheetViewController.swift[0m
+INFO [2022-09-08 10:51:07.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m URLSession+CachedDownloading.swift[0m
+INFO [2022-09-08 10:51:07.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PushNotificationSettingsRequestAPIModel.swift[0m
+INFO [2022-09-08 10:51:07.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchBaseViewController.swift[0m
+INFO [2022-09-08 10:51:07.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMInputEmailViewController.swift[0m
+INFO [2022-09-08 10:51:07.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMStore.swift[0m
+INFO [2022-09-08 10:51:07.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPaginationIndicator.swift[0m
+INFO [2022-09-08 10:51:07.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Binding+Bikemap.swift[0m
+INFO [2022-09-08 10:51:07.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapboxDirectionsEmulator.swift[0m
+INFO [2022-09-08 10:51:07.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOIAddCommentViewController.swift[0m
+INFO [2022-09-08 10:51:07.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IntentHandler.swift[0m
+INFO [2022-09-08 10:51:07.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Shimmer.swift[0m
+INFO [2022-09-08 10:51:07.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGoogle.swift[0m
+INFO [2022-09-08 10:51:07.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationBottomBannerProxy.swift[0m
+INFO [2022-09-08 10:51:07.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsAdAttribution.swift[0m
+INFO [2022-09-08 10:51:07.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMHostingCell.swift[0m
+INFO [2022-09-08 10:51:07.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOIComments.swift[0m
+INFO [2022-09-08 10:51:07.87]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PremiumFeature.swift[0m
+INFO [2022-09-08 10:51:07.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapSettingsSupplementaryViews.swift[0m
+INFO [2022-09-08 10:51:07.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SettingsView.swift[0m
+INFO [2022-09-08 10:51:07.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsBikemapServer.swift[0m
+INFO [2022-09-08 10:51:07.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m User+Notifications.swift[0m
+INFO [2022-09-08 10:51:08.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteSearchResult+Bikemap.swift[0m
+INFO [2022-09-08 10:51:08.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMProgressNotificationAPIModel.swift[0m
+INFO [2022-09-08 10:51:08.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSharedPOI.swift[0m
+INFO [2022-09-08 10:51:08.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideArchive.swift[0m
+INFO [2022-09-08 10:51:08.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDependencies.swift[0m
+INFO [2022-09-08 10:51:08.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Mapbox+Bikemap.swift[0m
+INFO [2022-09-08 10:51:08.67]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionsViewController.swift[0m
+INFO [2022-09-08 10:51:08.69]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerElementGridView.swift[0m
+INFO [2022-09-08 10:51:08.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionRowModel.swift[0m
+INFO [2022-09-08 10:51:08.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerElevationProfileMarker.swift[0m
+INFO [2022-09-08 10:51:08.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGroupActivityStore.swift[0m
+INFO [2022-09-08 10:51:08.77]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+OfflineMaps.swift[0m
+INFO [2022-09-08 10:51:08.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerTextFooterButton.swift[0m
+INFO [2022-09-08 10:51:08.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Assets.swift[0m
+INFO [2022-09-08 10:51:08.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDesignableButton.swift[0m
+INFO [2022-09-08 10:51:08.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAdAttribution.swift[0m
+INFO [2022-09-08 10:51:08.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBugReporter.swift[0m
+INFO [2022-09-08 10:51:08.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LocationWrapper.swift[0m
+INFO [2022-09-08 10:51:08.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIStackView+Bikemap.swift[0m
+INFO [2022-09-08 10:51:08.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFeedTitleLocalized.swift[0m
+INFO [2022-09-08 10:51:08.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSuggestionItem.swift[0m
+INFO [2022-09-08 10:51:08.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+Polylines.swift[0m
+INFO [2022-09-08 10:51:08.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapStylesManager.swift[0m
+INFO [2022-09-08 10:51:09.00]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Config.swift[0m
+INFO [2022-09-08 10:51:09.02]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePhotoCollectionViewCell.swift[0m
+INFO [2022-09-08 10:51:09.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapFeatureKeys.swift[0m
+INFO [2022-09-08 10:51:09.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailsViewController+Reloadable.swift[0m
+INFO [2022-09-08 10:51:09.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAlertController.swift[0m
+INFO [2022-09-08 10:51:09.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMHealthKit.swift[0m
+INFO [2022-09-08 10:51:09.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailsViewController.swift[0m
+INFO [2022-09-08 10:51:09.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ScrollDirection.swift[0m
+INFO [2022-09-08 10:51:09.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPurchaseViewController.swift[0m
+INFO [2022-09-08 10:51:09.17]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m View+Bikemap.swift[0m
+INFO [2022-09-08 10:51:09.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession+CoreApp.swift[0m
+INFO [2022-09-08 10:51:09.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerButtonsFooterView.swift[0m
+INFO [2022-09-08 10:51:09.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ProgessNotificationPagerView.swift[0m
+INFO [2022-09-08 10:51:09.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMImagePickerWrapper.swift[0m
+INFO [2022-09-08 10:51:09.26]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRide.swift[0m
+INFO [2022-09-08 10:51:09.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMyActivityBarChart.swift[0m
+INFO [2022-09-08 10:51:09.29]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMElevationProfileUIViewRepresentable.swift[0m
+INFO [2022-09-08 10:51:09.31]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFirebaseAnalytics.swift[0m
+INFO [2022-09-08 10:51:09.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAdapterProtocol.swift[0m
+INFO [2022-09-08 10:51:09.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsFCMToken.swift[0m
+INFO [2022-09-08 10:51:09.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SetHomeWorkView.swift[0m
+INFO [2022-09-08 10:51:09.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m ButtonStyle+Bikemap.swift[0m
+INFO [2022-09-08 10:51:09.40]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+WaypointsViewControllerDelegate.swift[0m
+INFO [2022-09-08 10:51:09.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGroupActivityAnnotation.swift[0m
+INFO [2022-09-08 10:51:09.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CyclingPathsProfileOptionsView.swift[0m
+INFO [2022-09-08 10:51:09.71]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMWidgetAnalyticsEvents.swift[0m
+INFO [2022-09-08 10:51:09.73]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAuthSessionManager.swift[0m
+INFO [2022-09-08 10:51:09.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PurchaseScreenStore.swift[0m
+INFO [2022-09-08 10:51:09.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMContextMenuActions.swift[0m
+INFO [2022-09-08 10:51:09.78]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Color+Bikemap.swift[0m
+INFO [2022-09-08 10:51:09.80]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMElevationProfileView.swift[0m
+INFO [2022-09-08 10:51:09.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIDevice+Bikemap.swift[0m
+INFO [2022-09-08 10:51:09.83]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCredentials+HTTP.swift[0m
+INFO [2022-09-08 10:51:09.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMReferAFriendPopup.swift[0m
+INFO [2022-09-08 10:51:09.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationRequest.swift[0m
+INFO [2022-09-08 10:51:09.88]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m User+Feedback.swift[0m
+INFO [2022-09-08 10:51:09.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionEditViewController.swift[0m
+INFO [2022-09-08 10:51:09.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NotificationBubbleViewType.swift[0m
+INFO [2022-09-08 10:51:09.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerElevationBackgroundView.swift[0m
+INFO [2022-09-08 10:51:09.94]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMShowOfflineMapsManager.swift[0m
+INFO [2022-09-08 10:51:09.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFallDetectionView.swift[0m
+INFO [2022-09-08 10:51:09.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikeComputerElevationGraphElementView.swift[0m
+INFO [2022-09-08 10:51:09.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMProgressView.swift[0m
+INFO [2022-09-08 10:51:10.01]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m WeeklyRideStatistics.swift[0m
+INFO [2022-09-08 10:51:10.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBottomSheetViewController.swift[0m
+INFO [2022-09-08 10:51:10.04]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MailView.swift[0m
+INFO [2022-09-08 10:51:10.06]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m MGLCoordinateBounds+Equatable.swift[0m
+INFO [2022-09-08 10:51:10.08]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFavouriteCollectionTableViewCell.swift[0m
+INFO [2022-09-08 10:51:10.09]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsOfflineMode.swift[0m
+INFO [2022-09-08 10:51:10.11]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SubCategoryCollectionViewCell.swift[0m
+INFO [2022-09-08 10:51:10.13]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTilePackUpdater.swift[0m
+INFO [2022-09-08 10:51:10.15]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionSelectionHeader.swift[0m
+INFO [2022-09-08 10:51:10.16]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMyActivityView.swift[0m
+INFO [2022-09-08 10:51:10.18]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOIAnnotation.swift[0m
+INFO [2022-09-08 10:51:10.19]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapButtonsContainerView.swift[0m
+INFO [2022-09-08 10:51:10.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UIViewControllerExtensions.swift[0m
+INFO [2022-09-08 10:51:10.23]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMContentTableViewCell.swift[0m
+INFO [2022-09-08 10:51:10.25]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m NotificationBubbleView.swift[0m
+INFO [2022-09-08 10:51:10.28]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationTopBannerProxy.swift[0m
+INFO [2022-09-08 10:51:10.30]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMyActivityHeaderView.swift[0m
+INFO [2022-09-08 10:51:10.33]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CyclingPathOption.swift[0m
+INFO [2022-09-08 10:51:10.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePlanner.swift[0m
+INFO [2022-09-08 10:51:10.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m CreateRouteCollectionAPIModel.swift[0m
+INFO [2022-09-08 10:51:10.41]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionsUpdater.swift[0m
+INFO [2022-09-08 10:51:10.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAlongRouteParameters.swift[0m
+INFO [2022-09-08 10:51:10.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m PolylineSimplification.swift[0m
+INFO [2022-09-08 10:51:10.48]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSession+Address.swift[0m
+INFO [2022-09-08 10:51:10.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDevOptsRetentionTrigger.swift[0m
+INFO [2022-09-08 10:51:10.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m AppDelegate.swift[0m
+INFO [2022-09-08 10:51:10.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNotificationContentView.swift[0m
+INFO [2022-09-08 10:51:10.60]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePointPin.swift[0m
+INFO [2022-09-08 10:51:10.61]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Notification+Route.swift[0m
+INFO [2022-09-08 10:51:10.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideViewController+Navigation.swift[0m
+INFO [2022-09-08 10:51:10.66]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m Bikemap[0m
+INFO [2022-09-08 10:51:13.14]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m 'SwiftLint'[0m
+INFO [2022-09-08 10:51:22.38]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m 'Add pods licenses'[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/zh_CN.txt[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/zh_TW.txt[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/zh_HK.txt[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/vi_VI.txt[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/uk.txt[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/vi_VN.txt[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/tr.txt[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testSignUpEmailAndLogout.json[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testSearchAndFindVienna.json[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testRideAlongRoute.json[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testPlanEditDeletePlannedRoute.json[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testRatingDialog.json[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testOfflineRouteDownload.json[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testOfflineRegionDownload.json[0m
+INFO [2022-09-08 10:51:22.52]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testLogInEmailAndLogout.json[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testGoToRideScreenAndFindBond.json[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testGoToMyRoutesAndCheckSubTabs.json[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testFilteringSorting.json[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testFacebookLoginAndLogout.json[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testDiscoverRouteNavigation.json[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testCloseFinishScreen.json[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/testBikeComputerFreeRide.json[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/sv_SE.txt[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/sr_RS.txt[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/sl_SI.txt[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/sk.txt[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/sk.lproj/terms.html[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/sk.lproj/stylesheet.css[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/sk.lproj/about-privacy.html[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/sk.lproj/about-bikemap.html[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/si.txt[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ru.txt[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ru.lproj/terms.html[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ru.lproj/stylesheet.css[0m
+INFO [2022-09-08 10:51:22.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ru.lproj/about-privacy.html[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ru.lproj/about-bikemap.html[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/routing-coverage.geojson[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ro.txt[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pt_PT.txt[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pt_BR.txt[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pt-BR.lproj/terms.html[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pt-BR.lproj/stylesheet.css[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pt-BR.lproj/about-privacy.html[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pt-BR.lproj/about-bikemap.html[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pl_PL.txt[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pl.lproj/terms.html[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pl.lproj/stylesheet.css[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pl.lproj/about-privacy.html[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/pl.lproj/about-bikemap.html[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/nl.txt[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/nl.lproj/terms.html[0m
+INFO [2022-09-08 10:51:22.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/nl.lproj/stylesheet.css[0m
+INFO [2022-09-08 10:51:22.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/nl.lproj/about-privacy.html[0m
+INFO [2022-09-08 10:51:22.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/nl.lproj/about-bikemap.html[0m
+INFO [2022-09-08 10:51:22.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ne.txt[0m
+INFO [2022-09-08 10:51:22.56]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/navigation-routing-example.json[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/lt_LT.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ko.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ja.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/it.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/it.lproj/terms.html[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/it.lproj/stylesheet.css[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/it.lproj/about-privacy.html[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/it.lproj/about-bikemap.html[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/in_ID.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/hu_HU.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/hr_HR.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/hsb.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/he.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/glossary.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/gl.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/gh-data.bundle[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/gallery.ckcomplication[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/fr_FR.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/fr.lproj/terms.html[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/fr_CH.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/fr.lproj/stylesheet.css[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/fr.lproj/about-privacy.html[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/fr.lproj/about-bikemap.html[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/fil.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/fi.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/fa.txt[0m
+INFO [2022-09-08 10:51:22.57]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/es.txt[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/es.lproj/terms.html[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/es.lproj/stylesheet.css[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/es.lproj/about-privacy.html[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/es.lproj/about-bikemap.html[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/eo.txt[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/en_US.txt[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/en.lproj/terms.html[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/en.lproj/stylesheet.css[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/en.lproj/about-privacy.html[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/en.lproj/about-bikemap.html[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/el.txt[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/de_DE.txt[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/de.lproj/terms.html[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/de.lproj/stylesheet.css[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/de.lproj/about-privacy.html[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/de.lproj/about-bikemap.html[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/da_DK.txt[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/cs_CZ.txt[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/cacheBundleTest.json[0m
+INFO [2022-09-08 10:51:22.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ca.txt[0m
+INFO [2022-09-08 10:51:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/bg.txt[0m
+INFO [2022-09-08 10:51:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/bundle.js[0m
+INFO [2022-09-08 10:51:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ast.txt[0m
+INFO [2022-09-08 10:51:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ar.txt[0m
+INFO [2022-09-08 10:51:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/airhorn.mp3[0m
+INFO [2022-09-08 10:51:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/TestAlongRoute.gpx[0m
+INFO [2022-09-08 10:51:22.59]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/Settings.bundle[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ProximaNova-Xbold.otf[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ProximaNova-Semibold.otf[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ProximaNova-RegIt.otf[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ProximaNova-Reg.otf[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ProximaNova-LightIt.otf[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ProximaNova-Light.otf[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ProximaNova-BoldIt.otf[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ProximaNova-Bold.otf[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/ProximaNova-Black.otf[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/OfflineMapStyle.json[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/MTKBasedOfflineStyle.json[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/Feeds.json[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/BikemapNearLoopRoute.gpx[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/BikemapMono-Bold.ttf[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/BikemapCore[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/BikemapAlongRouteLondon.gpx[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m InfoPlist.strings[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:51:22.63]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:51:22.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m InfoPlist.strings[0m
+INFO [2022-09-08 10:51:22.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:51:22.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m InfoPlist.strings[0m
+INFO [2022-09-08 10:51:22.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:51:22.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m InfoPlist.strings[0m
+INFO [2022-09-08 10:51:22.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:51:22.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m InfoPlist.strings[0m
+INFO [2022-09-08 10:51:22.64]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:51:22.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m InfoPlist.strings[0m
+INFO [2022-09-08 10:51:22.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:51:22.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m InfoPlist.strings[0m
+INFO [2022-09-08 10:51:22.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:51:22.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m InfoPlist.strings[0m
+INFO [2022-09-08 10:51:22.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m Localizable.strings[0m
+INFO [2022-09-08 10:51:22.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m InfoPlist.strings[0m
+INFO [2022-09-08 10:51:22.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m ProximaNova.plist[0m
+INFO [2022-09-08 10:51:22.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GoogleService-Info-Prod.plist[0m
+INFO [2022-09-08 10:51:22.65]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m GoogleService-Info-Devel.plist[0m
+INFO [2022-09-08 10:51:22.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRatePOIImageView.xib[0m
+INFO [2022-09-08 10:51:23.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapStyleCell.xib[0m
+INFO [2022-09-08 10:51:25.62]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSharedLocationBottomSheetViewController.xib[0m
+INFO [2022-09-08 10:51:25.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePlannerBottomSheetViewController.xib[0m
+INFO [2022-09-08 10:51:26.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePOIBSViewController.xib[0m
+INFO [2022-09-08 10:51:26.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOIBottomSheetViewController.xib[0m
+INFO [2022-09-08 10:51:26.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMBottomSheetViewController.xib[0m
+INFO [2022-09-08 10:51:26.12]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMReportBottomSheetViewController.xib[0m
+INFO [2022-09-08 10:51:26.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchHeaderView.xib[0m
+INFO [2022-09-08 10:51:26.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteCollectionTableViewCell.xib[0m
+INFO [2022-09-08 10:51:26.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFavouriteCollectionTableViewCell.xib[0m
+INFO [2022-09-08 10:51:26.21]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCollectionHeaderView.xib[0m
+INFO [2022-09-08 10:51:26.22]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SubCategoryCollectionViewCell.xib[0m
+INFO [2022-09-08 10:51:27.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOICategoryDetailViewController.xib[0m
+INFO [2022-09-08 10:51:27.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOIAddCommentViewController.xib[0m
+INFO [2022-09-08 10:51:27.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRideWaypointCell.xib[0m
+INFO [2022-09-08 10:51:27.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteCollectionViewCell.xib[0m
+INFO [2022-09-08 10:51:27.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteTableViewCell.xib[0m
+INFO [2022-09-08 10:51:27.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRatingView.xib[0m
+INFO [2022-09-08 10:51:27.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationStartBottomSheetViewController.xib[0m
+INFO [2022-09-08 10:51:27.84]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMElevationProfileView.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAngelSettingsViewController.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTagCollectionViewCell.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMStarView.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutePhotoCollectionViewCell.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRouteDetailsARViewController.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhotoCollectionViewCell.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPhotoCarouselView.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPasswordGeneratorNotificationView.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMapButtonsContainerView.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFallDetectionView.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMButtonsNotificationView.xib[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSetHomeWorkViewController.storyboard[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchResultsViewController.storyboard[0m
+INFO [2022-09-08 10:51:27.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m POICategories.storyboard[0m
+INFO [2022-09-08 10:51:27.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPOICommentsViewController.storyboard[0m
+INFO [2022-09-08 10:51:27.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m UserProfile.storyboard[0m
+INFO [2022-09-08 10:51:27.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m SignUpFlow.storyboard[0m
+INFO [2022-09-08 10:51:30.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteUpload.storyboard[0m
+INFO [2022-09-08 10:51:30.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteNavigationSettings.storyboard[0m
+INFO [2022-09-08 10:51:30.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m RouteDetails.storyboard[0m
+INFO [2022-09-08 10:51:30.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Ride.storyboard[0m
+INFO [2022-09-08 10:51:30.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Premium.storyboard[0m
+INFO [2022-09-08 10:51:30.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m Main.storyboard[0m
+INFO [2022-09-08 10:51:30.95]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m LaunchScreen.storyboard[0m
+INFO [2022-09-08 10:51:30.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchFilterViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSearchBottomSheetViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRegionPickerViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPurchaseViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionsListViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMOfflineRegionEditViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationProgressBottomSheetViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationPauseBottomSheetViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMKeepSubscribersViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFullscreenMapViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMEmptyStateViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationTopBanner.storyboard[0m
+INFO [2022-09-08 10:51:30.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationInstructionsTableViewController.storyboard[0m
+INFO [2022-09-08 10:51:30.98]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMFilteringBarViewController.storyboard[0m
+INFO [2022-09-08 10:51:37.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Info.plist[0m
+INFO [2022-09-08 10:51:37.97]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m 'SwiftGen'[0m
+INFO [2022-09-08 10:51:38.72]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Embed Pods Frameworks'[0m
+INFO [2022-09-08 10:51:46.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCredentials.swift[0m
+INFO [2022-09-08 10:51:46.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLaunchArguments.swift[0m
+INFO [2022-09-08 10:51:46.91]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCredentials+LaunchArguments.swift[0m
+INFO [2022-09-08 10:51:46.92]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLoggedInUITests.swift[0m
+INFO [2022-09-08 10:51:47.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnonymousUITests.swift[0m
+INFO [2022-09-08 10:51:47.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m XCTestCase+Bikemap.swift[0m
+INFO [2022-09-08 10:51:47.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAccountManager.swift[0m
+INFO [2022-09-08 10:51:47.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMUITestsExtensions.swift[0m
+INFO [2022-09-08 10:51:47.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPremiumUITests.swift[0m
+INFO [2022-09-08 10:51:47.36]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAuthProvider.swift[0m
+INFO [2022-09-08 10:51:47.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Info.plist[0m
+INFO [2022-09-08 10:51:47.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mRunning script[0m[0;35;49m '[CP] Check Pods Manifest.lock'[0m
+INFO [2022-09-08 10:51:47.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/PlugIns/BikemapTests.xctest/test_gpx4.gpx[0m
+INFO [2022-09-08 10:51:47.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/PlugIns/BikemapTests.xctest/test_gpx3.gpx[0m
+INFO [2022-09-08 10:51:47.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/PlugIns/BikemapTests.xctest/test_gpx2.gpx[0m
+INFO [2022-09-08 10:51:47.37]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/PlugIns/BikemapTests.xctest/test_gpx1.gpx[0m
+INFO [2022-09-08 10:51:48.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/PlugIns/BikemapTests.xctest/test_gpx0.gpx[0m
+INFO [2022-09-08 10:51:48.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/PlugIns/BikemapTests.xctest/BMPaginatorTests-SearchPage-2.json[0m
+INFO [2022-09-08 10:51:48.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/PlugIns/BikemapTests.xctest/BMPaginatorTests-SearchPage-1.json[0m
+INFO [2022-09-08 10:51:48.34]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCopying[0m[0;35;49m /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Build/Products/Debug-iphonesimulator/Bikemap.app/PlugIns/BikemapTests.xctest/BMPaginatorTests-SearchPage-0.json[0m
+INFO [2022-09-08 10:51:48.35]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikemapUITests_vers.c[0m
+INFO [2022-09-08 10:51:51.39]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDateTests.swift[0m
+INFO [2022-09-08 10:51:51.44]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPaginatorTests.swift[0m
+INFO [2022-09-08 10:51:51.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMissingNumberFinderTests.swift[0m
+INFO [2022-09-08 10:51:51.53]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPolylineTest.swift[0m
+INFO [2022-09-08 10:51:51.54]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMTestDataAccess.swift[0m
+INFO [2022-09-08 10:51:51.58]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPurchaseParameters.swift[0m
+INFO [2022-09-08 10:51:51.68]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMMTKTests.swift[0m
+INFO [2022-09-08 10:51:51.70]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNavigationSETests.swift[0m
+INFO [2022-09-08 10:51:51.74]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMSessionTests.swift[0m
+INFO [2022-09-08 10:51:51.75]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMLocationArrayTests.swift[0m
+INFO [2022-09-08 10:51:51.76]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDeepLinkTest.swift[0m
+INFO [2022-09-08 10:51:51.79]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMDirectionsTests.swift[0m
+INFO [2022-09-08 10:51:51.81]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMAnalyticsTests.swift[0m
+INFO [2022-09-08 10:51:51.82]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMPurchaseTests.swift[0m
+INFO [2022-09-08 10:51:51.85]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMCachedDownloadingTests.swift[0m
+INFO [2022-09-08 10:51:51.86]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMGPXImportTests.swift[0m
+INFO [2022-09-08 10:51:51.89]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m IndexPathTests.swift[0m
+INFO [2022-09-08 10:51:51.90]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMStringExtensionTests.swift[0m
+INFO [2022-09-08 10:51:51.93]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m XCTestCase+Bikemap.swift[0m
+INFO [2022-09-08 10:51:52.46]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMRoutingConfigDecodingTests.swift[0m
+INFO [2022-09-08 10:51:52.47]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BMNetworkManagerTests.swift[0m
+INFO [2022-09-08 10:51:52.50]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mCompiling[0m[0;35;49m BikemapTests_vers.c[0m
+INFO [2022-09-08 10:51:52.51]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m BikemapTests[0m
+INFO [2022-09-08 10:51:53.27]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m BikemapTests.xctest (in target 'BikemapTests' from project 'Bikemap')[0m
+INFO [2022-09-08 10:51:57.02]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m Bikemap.app (in target 'Bikemap' from project 'Bikemap')[0m
+INFO [2022-09-08 10:51:57.03]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mLinking[0m[0;35;49m BikemapUITests[0m
+INFO [2022-09-08 10:51:57.24]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mProcessing[0m[0;35;49m Info.plist[0m
+INFO [2022-09-08 10:51:57.32]: [0;35;49mRunning Tests: [0m[0;35;49m▸[0m[0;35;49m [0m[0;35;49mTouching[0m[0;35;49m BikemapUITests.xctest (in target 'BikemapUITests' from project 'Bikemap')[0m
+INFO [2022-09-08 10:51:58.43]: ▸ [0;35;49m    [0m[0;35;49mRun script build phase 'Setup Githooks for BartyCrouch' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'Bikemap' from project 'Bikemap')[0m
+INFO [2022-09-08 10:51:58.43]: ▸ [0;35;49m    [0m[0;35;49mRun script build phase 'Add pods licenses' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'Bikemap' from project 'Bikemap')[0m
+INFO [2022-09-08 10:51:58.43]: ▸ [0;35;49m    [0m[0;35;49mRun script build phase 'SwiftLint' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'Bikemap' from project 'Bikemap')[0m
+INFO [2022-09-08 10:51:58.43]: ▸ [0;35;49m    [0m[0;35;49mRun script build phase 'SwiftGen' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'Bikemap' from project 'Bikemap')[0m
+INFO [2022-09-08 10:51:58.43]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mTest build[0m[0;35;49m Succeeded[0m
++--------------------+---+
+|      Test Results      |
++--------------------+---+
+| Number of tests    | 0 |
+| Number of failures | [0;32;49m0[0m |
++--------------------+---+
+
+DEBUG [2022-09-08 10:51:58.46]: After building, found xctestrun files ["build/DerivedData/Build/Products/Bikemap_iphonesimulator16.0-x86_64.xctestrun"] (choosing 1st)
+DEBUG [2022-09-08 10:51:58.46]: Removing report files generated by the build
+DEBUG [2022-09-08 10:51:58.46]:   ./fastlane/test_output/report.junit
+DEBUG [2022-09-08 10:51:58.46]: Getting tests from xctestrun file at 'build/DerivedData/Build/Products/Bikemap_iphonesimulator16.0-x86_64.xctestrun'
+DEBUG [2022-09-08 10:51:58.57]: Found the following tests: BMPurchaseTests/testPurchaseParametersRestore
+	BMPurchaseTests/testPurchaseParametersUpgrade12to13
+	BMAnalyticsTests/testEventsStructure
+	BMGPXImportTests/testGPXImport
+	BMPaginatorTests/test_OnePage_Success
+	BMPaginatorTests/test_Pagination_Failure
+	BMPaginatorTests/test_Pagination_Success
+	BMLocationArrayTests/testDistance
+	BMLocationArrayTests/testDuration
+	BMLocationArrayTests/testRemainedLocations
+	BMLocationArrayTests/testElevationNormalisation
+	BMStringExtensionTests/testSlicesBetweenTwoTokens
+	BMCachedDownloadingTests/testFileFromBundle
+	BMCachedDownloadingTests/testDownloadAndSave
+	MissingNumberFinderTests/test1
+	MissingNumberFinderTests/test2
+	MissingNumberFinderTests/test3
+	MissingNumberFinderTests/test4
+	BMRoutingConfigDecodingTests/testSecretDecoding
+	BMRoutingConfigDecodingTests/testConfigDecoding
+	BMRoutingConfigDecodingTests/testSaltDecoding
+	BMDateTests/testDateMinutesDifference
+	IndexPathTests/testToString
+	IndexPathTests/testFromString
+	BMMTKTests/testFetchRoutingFileNotification
+	BMSessionTest/testHomeAddress
+	BMSessionTest/testWorkAddress
+	BMDeepLinkTest/testRouteShortLink
+	BMDeepLinkTest/testRouteLink
+	BMDeepLinkTest/testSearch
+	BMDeepLinkTest/testOffline
+	BMDeepLinkTest/testPremium
+	BMDeepLinkTest/testDiscover
+	BMDeepLinkTest/testRecorded
+	BMDeepLinkTest/testSavedRoutes
+	BMDeepLinkTest/testRoutePlanner
+	BMDeepLinkTest/testPlannedRoutes
+	BMDeepLinkTest/testShareLocation
+	BMDeepLinkTest/testStartFreeRide
+	BMDeepLinkTest/testNavigationSettings
+	BMDeepLinkTest/testRoutePlannerWithParameter
+	BMDeepLinkTest/testHandlingOfWrongUniversalLinks
+	BMDeepLinkTest/testHandlingOfCorrectUniversalLinks
+	BMPolylineTest/testLongPolyline
+	BMPolylineTest/testPolylineDecoding
+	BMDirectionsTest/testDirectionResponse
+	BMNavigationSETests/testBarcelona
+	BMNavigationSETests/testDegreeMod
+	BMNavigationSETests/testSaikogasse
+	BMNavigationSETests/testABCD
+DEBUG [2022-09-08 10:51:58.65]: Found the following tests: BMLoggedInUITests/testRatingDialog
+	BMLoggedInUITests/testRideAlongRoute
+	BMLoggedInUITests/testFilteringSorting
+	BMLoggedInUITests/testCloseFinishScreen
+	BMLoggedInUITests/testBikeComputerFreeRide
+	BMLoggedInUITests/testDiscoverRouteNavigation
+	BMLoggedInUITests/testGoToRideScreenAndFindBond
+	BMLoggedInUITests/testPlanEditDeletePlannedRoute
+	BMLoggedInUITests/testGoToMyRoutesAndCheckSubTabs
+	BMAnonymousUITests/testLogInEmailAndLogout
+	BMAnonymousUITests/testSearchAndFindVienna
+	BMAnonymousUITests/testSignUpEmailAndLogout
+	BMAnonymousUITests/testFacebookLoginAndLogout
+DEBUG [2022-09-08 10:51:58.65]: Removing skipped tests: 
+DEBUG [2022-09-08 10:51:58.65]: Identifiers after removing skipped tests: BMLoggedInUITests/testRatingDialog
+	BMLoggedInUITests/testRideAlongRoute
+	BMLoggedInUITests/testFilteringSorting
+	BMLoggedInUITests/testCloseFinishScreen
+	BMLoggedInUITests/testBikeComputerFreeRide
+	BMLoggedInUITests/testDiscoverRouteNavigation
+	BMLoggedInUITests/testGoToRideScreenAndFindBond
+	BMLoggedInUITests/testPlanEditDeletePlannedRoute
+	BMLoggedInUITests/testGoToMyRoutesAndCheckSubTabs
+	BMAnonymousUITests/testLogInEmailAndLogout
+	BMAnonymousUITests/testSearchAndFindVienna
+	BMAnonymousUITests/testSignUpEmailAndLogout
+	BMAnonymousUITests/testFacebookLoginAndLogout
+DEBUG [2022-09-08 10:51:58.65]: > setup_logcollection
+DEBUG [2022-09-08 10:51:58.65]: < done in TestCenter::Helper::MultiScanManager.initialize
+INFO [2022-09-08 10:51:58.79]: Testing batches for device 'iPhone 8'
+INFO [2022-09-08 10:51:58.79]: Starting test run 1
+DEBUG [2022-09-08 10:51:58.79]: Deleting xcresults:
+DEBUG [2022-09-08 10:51:58.79]: Restarting Simulator D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E
+DEBUG [2022-09-08 10:51:59.83]: retrying_scan #update_scan_options
+DEBUG [2022-09-08 10:51:59.83]: 	Setting workspace to /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/Bikemap.xcworkspace
+DEBUG [2022-09-08 10:51:59.83]: 	Setting fail_build to true
+DEBUG [2022-09-08 10:51:59.83]: 	Setting scheme to Bikemap
+DEBUG [2022-09-08 10:51:59.83]: 	Setting output_types to junit
+DEBUG [2022-09-08 10:51:59.83]: 	Setting skip_detect_devices to false
+DEBUG [2022-09-08 10:51:59.83]: 	Setting ensure_devices_found to false
+DEBUG [2022-09-08 10:51:59.83]: 	Setting reset_simulator to false
+DEBUG [2022-09-08 10:51:59.83]: 	Setting disable_slide_to_type to true
+DEBUG [2022-09-08 10:51:59.83]: 	Setting prelaunch_simulator to true
+DEBUG [2022-09-08 10:51:59.83]: 	Setting reinstall_app to false
+DEBUG [2022-09-08 10:51:59.83]: 	Setting app_identifier to com.toursprung.bikemap
+DEBUG [2022-09-08 10:51:59.83]: 	Setting only_testing to ["BikemapTests/BMPurchaseTests/testPurchaseParametersRestore", "BikemapTests/BMPurchaseTests/testPurchaseParametersUpgrade12to13", "BikemapTests/BMAnalyticsTests/testEventsStructure", "BikemapTests/BMGPXImportTests/testGPXImport", "BikemapTests/BMPaginatorTests/test_OnePage_Success", "BikemapTests/BMPaginatorTests/test_Pagination_Failure", "BikemapTests/BMPaginatorTests/test_Pagination_Success", "BikemapTests/BMLocationArrayTests/testDistance", "BikemapTests/BMLocationArrayTests/testDuration", "BikemapTests/BMLocationArrayTests/testRemainedLocations", "BikemapTests/BMLocationArrayTests/testElevationNormalisation", "BikemapTests/BMStringExtensionTests/testSlicesBetweenTwoTokens", "BikemapTests/BMCachedDownloadingTests/testFileFromBundle", "BikemapTests/BMCachedDownloadingTests/testDownloadAndSave", "BikemapTests/MissingNumberFinderTests/test1", "BikemapTests/MissingNumberFinderTests/test2", "BikemapTests/MissingNumberFinderTests/test3", "BikemapTests/MissingNumberFinderTests/test4", "BikemapTests/BMRoutingConfigDecodingTests/testSecretDecoding", "BikemapTests/BMRoutingConfigDecodingTests/testConfigDecoding", "BikemapTests/BMRoutingConfigDecodingTests/testSaltDecoding", "BikemapTests/BMDateTests/testDateMinutesDifference", "BikemapTests/IndexPathTests/testToString", "BikemapTests/IndexPathTests/testFromString", "BikemapTests/BMMTKTests/testFetchRoutingFileNotification", "BikemapTests/BMSessionTest/testHomeAddress", "BikemapTests/BMSessionTest/testWorkAddress", "BikemapTests/BMDeepLinkTest/testRouteShortLink", "BikemapTests/BMDeepLinkTest/testRouteLink", "BikemapTests/BMDeepLinkTest/testSearch", "BikemapTests/BMDeepLinkTest/testOffline", "BikemapTests/BMDeepLinkTest/testPremium", "BikemapTests/BMDeepLinkTest/testDiscover", "BikemapTests/BMDeepLinkTest/testRecorded", "BikemapTests/BMDeepLinkTest/testSavedRoutes", "BikemapTests/BMDeepLinkTest/testRoutePlanner", "BikemapTests/BMDeepLinkTest/testPlannedRoutes", "BikemapTests/BMDeepLinkTest/testShareLocation", "BikemapTests/BMDeepLinkTest/testStartFreeRide", "BikemapTests/BMDeepLinkTest/testNavigationSettings", "BikemapTests/BMDeepLinkTest/testRoutePlannerWithParameter", "BikemapTests/BMDeepLinkTest/testHandlingOfWrongUniversalLinks", "BikemapTests/BMDeepLinkTest/testHandlingOfCorrectUniversalLinks", "BikemapTests/BMPolylineTest/testLongPolyline", "BikemapTests/BMPolylineTest/testPolylineDecoding", "BikemapTests/BMDirectionsTest/testDirectionResponse", "BikemapTests/BMNavigationSETests/testBarcelona", "BikemapTests/BMNavigationSETests/testDegreeMod", "BikemapTests/BMNavigationSETests/testSaikogasse", "BikemapTests/BMNavigationSETests/testABCD"]
+DEBUG [2022-09-08 10:51:59.83]: 	Setting xctestrun to build/DerivedData/Build/Products/Bikemap_iphonesimulator16.0-x86_64.xctestrun
+DEBUG [2022-09-08 10:51:59.83]: 	Setting clean to false
+DEBUG [2022-09-08 10:51:59.83]: 	Setting open_report to false
+DEBUG [2022-09-08 10:51:59.83]: 	Setting output_directory to /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapTests-batch-1
+DEBUG [2022-09-08 10:51:59.83]: 	Setting output_files to report.junit
+DEBUG [2022-09-08 10:51:59.83]: 	Setting buildlog_path to ~/Library/Logs/scan
+DEBUG [2022-09-08 10:51:59.83]: 	Setting include_simulator_logs to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting derived_data_path to build/DerivedData
+DEBUG [2022-09-08 10:51:59.84]: 	Setting should_zip_build_products to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting output_xctestrun to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting result_bundle to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting use_clang_report_name to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting disable_concurrent_testing to true
+DEBUG [2022-09-08 10:51:59.84]: 	Setting build_for_testing to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting xcargs to -UseNewBuildSystem=YES -parallel-testing-enabled NO 
+DEBUG [2022-09-08 10:51:59.84]: 	Setting slack_use_webhook_configured_username_and_icon to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting slack_username to fastlane
+DEBUG [2022-09-08 10:51:59.84]: 	Setting slack_icon_url to https://fastlane.tools/assets/img/fastlane_icon.png
+DEBUG [2022-09-08 10:51:59.84]: 	Setting skip_slack to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting slack_only_on_failure to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting destination to ["platform=iOS Simulator,id=D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E"]
+DEBUG [2022-09-08 10:51:59.84]: 	Setting xcodebuild_command to env NSUnbufferedIO=YES xcodebuild
+DEBUG [2022-09-08 10:51:59.84]: 	Setting skip_package_dependencies_resolution to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting disable_package_automatic_updates to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting use_system_scm to false
+DEBUG [2022-09-08 10:51:59.84]: 	Setting number_of_retries to 0
+DEBUG [2022-09-08 10:51:59.84]: 	Setting skip_build to false
+
++------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  [0;32;49mSummary for scan 2.200.0[0m                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
++------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| workspace                                      | /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/Bikemap.xcworkspace                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| fail_build                                     | true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| scheme                                         | Bikemap                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| output_types                                   | junit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| skip_detect_devices                            | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| ensure_devices_found                           | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| force_quit_simulator                           | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| reset_simulator                                | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| disable_slide_to_type                          | true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| prelaunch_simulator                            | true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| reinstall_app                                  | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| app_identifier                                 | com.toursprung.bikemap                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| only_testing                                   | ["BikemapTests/BMPurchaseTests/testPurchaseParametersRestore", "BikemapTests/BMPurchaseTests/testPurchaseParametersUpgrade12to13", "BikemapTests/BMAnalyticsTests/testEventsStructure", "BikemapTests/BMGPXImportTests/testGPXImport", "BikemapTests/BMPaginatorTests/test_OnePage_Success", "BikemapTests/BMPaginatorTests/test_Pagination_Failure", "BikemapTests/BMPaginatorTests/test_Pagination_Success", "BikemapTests/BMLocationArrayTests/testDistance", "BikemapTests/BMLocationArrayTests/testDuration", "BikemapTests/BMLocationArrayTests/testRemainedLocations", "BikemapTests/BMLocationArrayTests/testElevationNormalisation", "BikemapTests/BMStringExtensionTests/testSlicesBetweenTwoTokens", "BikemapTests/BMCachedDownloadingTests/testFileFromBundle", "BikemapTests/BMCachedDownloadingTests/testDownloadAndSave", "BikemapTests/MissingNumberFinderTests/test1", "BikemapTests/MissingNumberFinderTests/test2", "BikemapTests/MissingNumberFinderTests/test3", "BikemapTests/MissingNumberFinderTests/test4", "BikemapTests/BMRoutingConfigDecodingTests/testSecretDecoding", "BikemapTests/BMRoutingConfigDecodingTests/testConfigDecoding", "BikemapTests/BMRoutingConfigDecodingTests/testSaltDecoding", "BikemapTests/BMDateTests/testDateMinutesDifference", "BikemapTests/IndexPathTests/testToString", "BikemapTests/IndexPathTests/testFromString", "BikemapTests/BMMTKTests/testFetchRoutingFileNotification", "BikemapTests/BMSessionTest/testHomeAddress", "BikemapTests/BMSessionTest/testWorkAddress", "BikemapTests/BMDeepLinkTest/testRouteShortLink", "BikemapTests/BMDeepLinkTest/testRouteLink", "BikemapTests/BMDeepLinkTest/testSearch", "BikemapTests/BMDeepLinkTest/testOffline", "BikemapTests/BMDeepLinkTest/testPremium", "BikemapTests/BMDeepLinkTest/testDiscover", "BikemapTests/BMDeepLinkTest/testRecorded", "BikemapTests/BMDeepLinkTest/testSavedRoutes", "BikemapTests/BMDeepLinkTest/testRoutePlanner", "BikemapTests/BMDeepLinkTest/testPlannedRoutes", "BikemapTests/BMDeepLinkTest/testShareLocation", "BikemapTests/BMDeepLinkTest/testStartFreeRide", "BikemapTests/BMDeepLinkTest/testNavigationSettings", "BikemapTests/BMDeepLinkTest/testRoutePlannerWithParameter", "BikemapTests/BMDeepLinkTest/testHandlingOfWrongUniversalLinks", "BikemapTests/BMDeepLinkTest/testHandlingOfCorrectUniversalLinks", "BikemapTests/BMPolylineTest/testLongPolyline", "BikemapTests/BMPolylineTest/testPolylineDecoding", "BikemapTests/BMDirectionsTest/testDirectionResponse", "BikemapTests/BMNavigationSETests/testBarcelona", "BikemapTests/BMNavigationSETests/testDegreeMod", "BikemapTests/BMNavigationSETests/testSaikogasse", "BikemapTests/BMNavigationSETests/testABCD"] |
+| xctestrun                                      | build/DerivedData/Build/Products/Bikemap_iphonesimulator16.0-x86_64.xctestrun                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| clean                                          | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| open_report                                    | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| output_directory                               | /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapTests-batch-1                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| output_files                                   | report.junit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| buildlog_path                                  | ~/Library/Logs/scan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| derived_data_path                              | build/DerivedData                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| should_zip_build_products                      | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| output_xctestrun                               | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| use_clang_report_name                          | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| disable_concurrent_testing                     | true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| xcargs                                         | -UseNewBuildSystem=YES -parallel-testing-enabled NO                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| slack_use_webhook_configured_username_and_icon | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| slack_username                                 | fastlane                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| slack_icon_url                                 | https://fastlane.tools/assets/img/fastlane_icon.png                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| skip_slack                                     | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| slack_only_on_failure                          | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| xcodebuild_command                             | env NSUnbufferedIO=YES xcodebuild                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| skip_package_dependencies_resolution           | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| disable_package_automatic_updates              | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| use_system_scm                                 | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| number_of_retries                              | 0                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| include_simulator_logs                         | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| skip_build                                     | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| xcode_path                                     | /Applications/Xcode-beta.app                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| result_bundle                                  | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| build_for_testing                              | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| devices                                        | ["iPhone 8"]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
++------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+INFO [2022-09-08 10:51:59.87]: Starting scan #1 with 50 tests for batch #1.
+DEBUG [2022-09-08 10:51:59.87]: Fetching available simulator devices
+INFO [2022-09-08 10:52:00.39]: Disabling 'Slide to Type' iPhone 8
+INFO [2022-09-08 10:52:00.39]: [0;36;49m$ /usr/libexec/PlistBuddy -c "Add :KeyboardContinuousPathEnabled bool false" /Users/bikemap/Library/Developer/CoreSimulator/Devices/D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E/data/Library/Preferences/com.apple.keyboard.ContinuousPath.plist >/dev/null 2>&1[0m
+INFO [2022-09-08 10:52:00.41]: [0;36;49m$ set -o pipefail && env NSUnbufferedIO=YES xcodebuild -destination 'platform=iOS Simulator,id=D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E' -derivedDataPath build/DerivedData -disable-concurrent-testing -xctestrun 'build/DerivedData/Build/Products/Bikemap_iphonesimulator16.0-x86_64.xctestrun' -UseNewBuildSystem=YES -parallel-testing-enabled NO  -only-testing:BikemapTests/BMPurchaseTests/testPurchaseParametersRestore -only-testing:BikemapTests/BMPurchaseTests/testPurchaseParametersUpgrade12to13 -only-testing:BikemapTests/BMAnalyticsTests/testEventsStructure -only-testing:BikemapTests/BMGPXImportTests/testGPXImport -only-testing:BikemapTests/BMPaginatorTests/test_OnePage_Success -only-testing:BikemapTests/BMPaginatorTests/test_Pagination_Failure -only-testing:BikemapTests/BMPaginatorTests/test_Pagination_Success -only-testing:BikemapTests/BMLocationArrayTests/testDistance -only-testing:BikemapTests/BMLocationArrayTests/testDuration -only-testing:BikemapTests/BMLocationArrayTests/testRemainedLocations -only-testing:BikemapTests/BMLocationArrayTests/testElevationNormalisation -only-testing:BikemapTests/BMStringExtensionTests/testSlicesBetweenTwoTokens -only-testing:BikemapTests/BMCachedDownloadingTests/testFileFromBundle -only-testing:BikemapTests/BMCachedDownloadingTests/testDownloadAndSave -only-testing:BikemapTests/MissingNumberFinderTests/test1 -only-testing:BikemapTests/MissingNumberFinderTests/test2 -only-testing:BikemapTests/MissingNumberFinderTests/test3 -only-testing:BikemapTests/MissingNumberFinderTests/test4 -only-testing:BikemapTests/BMRoutingConfigDecodingTests/testSecretDecoding -only-testing:BikemapTests/BMRoutingConfigDecodingTests/testConfigDecoding -only-testing:BikemapTests/BMRoutingConfigDecodingTests/testSaltDecoding -only-testing:BikemapTests/BMDateTests/testDateMinutesDifference -only-testing:BikemapTests/IndexPathTests/testToString -only-testing:BikemapTests/IndexPathTests/testFromString -only-testing:BikemapTests/BMMTKTests/testFetchRoutingFileNotification -only-testing:BikemapTests/BMSessionTest/testHomeAddress -only-testing:BikemapTests/BMSessionTest/testWorkAddress -only-testing:BikemapTests/BMDeepLinkTest/testRouteShortLink -only-testing:BikemapTests/BMDeepLinkTest/testRouteLink -only-testing:BikemapTests/BMDeepLinkTest/testSearch -only-testing:BikemapTests/BMDeepLinkTest/testOffline -only-testing:BikemapTests/BMDeepLinkTest/testPremium -only-testing:BikemapTests/BMDeepLinkTest/testDiscover -only-testing:BikemapTests/BMDeepLinkTest/testRecorded -only-testing:BikemapTests/BMDeepLinkTest/testSavedRoutes -only-testing:BikemapTests/BMDeepLinkTest/testRoutePlanner -only-testing:BikemapTests/BMDeepLinkTest/testPlannedRoutes -only-testing:BikemapTests/BMDeepLinkTest/testShareLocation -only-testing:BikemapTests/BMDeepLinkTest/testStartFreeRide -only-testing:BikemapTests/BMDeepLinkTest/testNavigationSettings -only-testing:BikemapTests/BMDeepLinkTest/testRoutePlannerWithParameter -only-testing:BikemapTests/BMDeepLinkTest/testHandlingOfWrongUniversalLinks -only-testing:BikemapTests/BMDeepLinkTest/testHandlingOfCorrectUniversalLinks -only-testing:BikemapTests/BMPolylineTest/testLongPolyline -only-testing:BikemapTests/BMPolylineTest/testPolylineDecoding -only-testing:BikemapTests/BMDirectionsTest/testDirectionResponse -only-testing:BikemapTests/BMNavigationSETests/testBarcelona -only-testing:BikemapTests/BMNavigationSETests/testDegreeMod -only-testing:BikemapTests/BMNavigationSETests/testSaikogasse -only-testing:BikemapTests/BMNavigationSETests/testABCD test-without-building | tee '/Users/bikemap/Library/Logs/scan/Bikemap-Bikemap.log' | xcpretty  --report junit --output '/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapTests-batch-1/report.junit' --report junit --output '/var/folders/k9/2frl09_n32vfltrncztxx4_m0000gn/T/junit_report20220908-35977-1p0dnei' [0m
+INFO [2022-09-08 10:52:00.41]: ▸ [0;35;49mLoading...[0m
+INFO [2022-09-08 10:52:35.47]: ▸ [0;35;49mSelected tests[0m
+INFO [2022-09-08 10:52:35.47]: ▸ [0;35;49mTest Suite [0m[0;35;49mBikemapTests.xctest[0m[0;35;49m started[0m
+INFO [2022-09-08 10:52:35.48]: ▸ [0;35;49mBMAnalyticsTests[0m
+INFO [2022-09-08 10:52:35.49]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testEventsStructure (0.012 seconds)[0m
+INFO [2022-09-08 10:52:35.49]: ▸ [0;35;49mBMCachedDownloadingTests[0m
+INFO [2022-09-08 10:52:35.66]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testDownloadAndSave ([0m[0;35;49m0.169[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:35.67]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testFileFromBundle (0.012 seconds)[0m
+INFO [2022-09-08 10:52:35.67]: ▸ [0;35;49mBMDateTests[0m
+INFO [2022-09-08 10:52:35.67]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testDateMinutesDifference (0.004 seconds)[0m
+INFO [2022-09-08 10:52:35.68]: ▸ [0;35;49mBMDeepLinkTest[0m
+INFO [2022-09-08 10:52:35.68]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testDiscover (0.007 seconds)[0m
+INFO [2022-09-08 10:52:35.74]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testHandlingOfCorrectUniversalLinks ([0m[0;35;49m0.055[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:35.74]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testHandlingOfWrongUniversalLinks (0.004 seconds)[0m
+INFO [2022-09-08 10:52:35.75]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testNavigationSettings (0.003 seconds)[0m
+INFO [2022-09-08 10:52:35.75]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testOffline (0.002 seconds)[0m
+INFO [2022-09-08 10:52:35.75]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testPlannedRoutes (0.003 seconds)[0m
+INFO [2022-09-08 10:52:35.76]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testPremium (0.003 seconds)[0m
+INFO [2022-09-08 10:52:35.76]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testRecorded (0.002 seconds)[0m
+INFO [2022-09-08 10:52:35.76]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testRouteLink (0.003 seconds)[0m
+INFO [2022-09-08 10:52:35.77]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testRoutePlanner (0.004 seconds)[0m
+INFO [2022-09-08 10:52:35.77]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testRoutePlannerWithParameter (0.003 seconds)[0m
+INFO [2022-09-08 10:52:35.77]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testRouteShortLink (0.003 seconds)[0m
+INFO [2022-09-08 10:52:35.78]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testSavedRoutes (0.002 seconds)[0m
+INFO [2022-09-08 10:52:35.78]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testSearch (0.002 seconds)[0m
+INFO [2022-09-08 10:52:35.78]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testShareLocation (0.003 seconds)[0m
+INFO [2022-09-08 10:52:35.78]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testStartFreeRide (0.003 seconds)[0m
+INFO [2022-09-08 10:52:35.78]: ▸ [0;35;49mBMDirectionsTest[0m
+INFO [2022-09-08 10:52:36.11]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testDirectionResponse ([0m[0;35;49m0.324[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:36.11]: ▸ [0;35;49mBMGPXImportTests[0m
+INFO [2022-09-08 10:52:38.80]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testGPXImport ([0m[0;35;49m2.687[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:38.80]: ▸ [0;35;49mBMLocationArrayTests[0m
+INFO [2022-09-08 10:52:38.80]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testDistance (0.002 seconds)[0m
+INFO [2022-09-08 10:52:38.80]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testDuration (0.002 seconds)[0m
+INFO [2022-09-08 10:52:38.80]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testElevationNormalisation (0.002 seconds)[0m
+INFO [2022-09-08 10:52:38.81]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testRemainedLocations (0.002 seconds)[0m
+INFO [2022-09-08 10:52:38.81]: ▸ [0;35;49mBMMTKTests[0m
+INFO [2022-09-08 10:52:38.98]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testFetchRoutingFileNotification ([0m[0;35;49m0.171[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:38.98]: ▸ [0;35;49mBMNavigationSETests[0m
+INFO [2022-09-08 10:52:39.24]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testABCD ([0m[0;35;49m0.263[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:39.41]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testBarcelona ([0m[0;35;49m0.166[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:39.41]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testDegreeMod (0.005 seconds)[0m
+INFO [2022-09-08 10:52:39.57]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testSaikogasse ([0m[0;35;49m0.152[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:39.57]: ▸ [0;35;49mBMPaginatorTests[0m
+INFO [2022-09-08 10:52:39.60]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m test_OnePage_Success ([0m[0;35;49m0.029[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:39.63]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m test_Pagination_Failure ([0m[0;35;49m0.037[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:39.67]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m test_Pagination_Success ([0m[0;35;49m0.036[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:39.67]: ▸ [0;35;49mBMPolylineTest[0m
+INFO [2022-09-08 10:52:40.22]: ▸ [0;35;49m    [0m[0;35;49m◷[0m[0;35;49m testLongPolyline measured (0.009 seconds)[0m
+INFO [2022-09-08 10:52:40.22]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testLongPolyline ([0m[0;35;49m0.544[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:40.48]: ▸ [0;35;49m    [0m[0;35;49m◷[0m[0;35;49m testPolylineDecoding measured (0.001 seconds)[0m
+INFO [2022-09-08 10:52:40.49]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testPolylineDecoding ([0m[0;35;49m0.262[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:52:40.49]: ▸ [0;35;49mBMPurchaseTests[0m
+INFO [2022-09-08 10:52:40.49]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testPurchaseParametersRestore (0.007 seconds)[0m
+INFO [2022-09-08 10:52:40.49]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testPurchaseParametersUpgrade12to13 (0.004 seconds)[0m
+INFO [2022-09-08 10:52:40.49]: ▸ [0;35;49mBMRoutingConfigDecodingTests[0m
+INFO [2022-09-08 10:52:40.50]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testConfigDecoding (0.003 seconds)[0m
+INFO [2022-09-08 10:52:40.50]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testSaltDecoding (0.002 seconds)[0m
+INFO [2022-09-08 10:52:40.51]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testSecretDecoding (0.002 seconds)[0m
+INFO [2022-09-08 10:52:40.51]: ▸ [0;35;49mBMSessionTest[0m
+INFO [2022-09-08 10:52:40.51]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testHomeAddress (0.011 seconds)[0m
+INFO [2022-09-08 10:52:40.52]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testWorkAddress (0.004 seconds)[0m
+INFO [2022-09-08 10:52:40.52]: ▸ [0;35;49mBMStringExtensionTests[0m
+INFO [2022-09-08 10:52:40.52]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testSlicesBetweenTwoTokens (0.002 seconds)[0m
+INFO [2022-09-08 10:52:40.52]: ▸ [0;35;49mIndexPathTests[0m
+INFO [2022-09-08 10:52:40.52]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testFromString (0.002 seconds)[0m
+INFO [2022-09-08 10:52:40.52]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testToString (0.002 seconds)[0m
+INFO [2022-09-08 10:52:40.53]: ▸ [0;35;49mMissingNumberFinderTests[0m
+INFO [2022-09-08 10:52:40.53]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m test1 (0.002 seconds)[0m
+INFO [2022-09-08 10:52:40.53]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m test2 (0.002 seconds)[0m
+INFO [2022-09-08 10:52:40.53]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m test3 (0.002 seconds)[0m
+INFO [2022-09-08 10:52:40.53]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m test4 (0.001 seconds)[0m
+INFO [2022-09-08 10:52:40.53]: ▸ [0;35;49m[32;1m	 Executed 50 tests, with 0 failures (0 unexpected) in 5.027 (5.061) seconds[0m
+INFO [2022-09-08 10:52:40.53]: ▸ [0;35;49m[0m[0m
+INFO [2022-09-08 10:52:40.85]: ▸ [0;35;49m2022-09-08 10:52:40.850 xcodebuild[43204:21341013] [MT] IDETestOperationsObserverDebug: 33.067 elapsed -- Testing started completed.[0m
+INFO [2022-09-08 10:52:40.85]: ▸ [0;35;49m2022-09-08 10:52:40.850 xcodebuild[43204:21341013] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start[0m
+INFO [2022-09-08 10:52:40.85]: ▸ [0;35;49m2022-09-08 10:52:40.850 xcodebuild[43204:21341013] [MT] IDETestOperationsObserverDebug: 33.067 sec, +33.067 sec -- end[0m
+INFO [2022-09-08 10:52:40.99]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mTest execute[0m[0;35;49m Succeeded[0m
++--------------------+----+
+|      Test Results       |
++--------------------+----+
+| Number of tests    | 50 |
+| Number of failures | [0;32;49m0[0m  |
++--------------------+----+
+
+DEBUG [2022-09-08 10:52:41.03]: Batch #1 incrementing retry count to 1
+DEBUG [2022-09-08 10:52:41.03]: Scan passed the tests for batch #1
+INFO [2022-09-08 10:52:41.10]: [0;32;49m-----------------------------------------------------[0m
+INFO [2022-09-08 10:52:41.10]: [0;32;49mStep: set-simulator-location -c 51.510279 -0.138947[0m
+INFO [2022-09-08 10:52:41.10]: [0;32;49m-----------------------------------------------------[0m
+INFO [2022-09-08 10:52:41.10]: [0;36;49m$ set-simulator-location -c 51.510279 -0.138947[0m
+INFO [2022-09-08 10:52:41.37]: ▸ [0;35;49mSetting location to 51.510279 -0.138947[0m
+DEBUG [2022-09-08 10:52:41.37]: ReportCollator collating
+INFO [2022-09-08 10:52:41.37]: Starting test run 2
+DEBUG [2022-09-08 10:52:41.38]: Deleting xcresults:
+DEBUG [2022-09-08 10:52:41.38]:   /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/build/DerivedData/Logs/Test/Test-Bikemap-2022.09.08_10-52-07-+0200.xcresult
+DEBUG [2022-09-08 10:52:41.38]: Restarting Simulator D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E
+DEBUG [2022-09-08 10:52:45.04]: retrying_scan #update_scan_options
+DEBUG [2022-09-08 10:52:45.04]: 	Setting workspace to /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/Bikemap.xcworkspace
+DEBUG [2022-09-08 10:52:45.04]: 	Setting fail_build to true
+DEBUG [2022-09-08 10:52:45.04]: 	Setting scheme to Bikemap
+DEBUG [2022-09-08 10:52:45.04]: 	Setting output_types to junit
+DEBUG [2022-09-08 10:52:45.04]: 	Setting skip_detect_devices to false
+DEBUG [2022-09-08 10:52:45.04]: 	Setting ensure_devices_found to false
+DEBUG [2022-09-08 10:52:45.04]: 	Setting reset_simulator to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting disable_slide_to_type to true
+DEBUG [2022-09-08 10:52:45.05]: 	Setting prelaunch_simulator to true
+DEBUG [2022-09-08 10:52:45.05]: 	Setting reinstall_app to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting app_identifier to com.toursprung.bikemap
+DEBUG [2022-09-08 10:52:45.05]: 	Setting only_testing to ["BikemapUITests/BMLoggedInUITests/testRatingDialog", "BikemapUITests/BMLoggedInUITests/testRideAlongRoute", "BikemapUITests/BMLoggedInUITests/testFilteringSorting", "BikemapUITests/BMLoggedInUITests/testCloseFinishScreen", "BikemapUITests/BMLoggedInUITests/testBikeComputerFreeRide", "BikemapUITests/BMLoggedInUITests/testDiscoverRouteNavigation", "BikemapUITests/BMLoggedInUITests/testGoToRideScreenAndFindBond", "BikemapUITests/BMLoggedInUITests/testPlanEditDeletePlannedRoute", "BikemapUITests/BMLoggedInUITests/testGoToMyRoutesAndCheckSubTabs", "BikemapUITests/BMAnonymousUITests/testLogInEmailAndLogout", "BikemapUITests/BMAnonymousUITests/testSearchAndFindVienna", "BikemapUITests/BMAnonymousUITests/testSignUpEmailAndLogout", "BikemapUITests/BMAnonymousUITests/testFacebookLoginAndLogout"]
+DEBUG [2022-09-08 10:52:45.05]: 	Setting xctestrun to build/DerivedData/Build/Products/Bikemap_iphonesimulator16.0-x86_64.xctestrun
+DEBUG [2022-09-08 10:52:45.05]: 	Setting clean to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting open_report to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting output_directory to /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapUITests-batch-2
+DEBUG [2022-09-08 10:52:45.05]: 	Setting output_files to report.junit
+DEBUG [2022-09-08 10:52:45.05]: 	Setting buildlog_path to ~/Library/Logs/scan
+DEBUG [2022-09-08 10:52:45.05]: 	Setting include_simulator_logs to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting derived_data_path to build/DerivedData
+DEBUG [2022-09-08 10:52:45.05]: 	Setting should_zip_build_products to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting output_xctestrun to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting result_bundle to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting use_clang_report_name to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting disable_concurrent_testing to true
+DEBUG [2022-09-08 10:52:45.05]: 	Setting build_for_testing to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting xcargs to -UseNewBuildSystem=YES   -parallel-testing-enabled NO 
+DEBUG [2022-09-08 10:52:45.05]: 	Setting slack_use_webhook_configured_username_and_icon to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting slack_username to fastlane
+DEBUG [2022-09-08 10:52:45.05]: 	Setting slack_icon_url to https://fastlane.tools/assets/img/fastlane_icon.png
+DEBUG [2022-09-08 10:52:45.05]: 	Setting skip_slack to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting slack_only_on_failure to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting destination to ["platform=iOS Simulator,id=D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E"]
+DEBUG [2022-09-08 10:52:45.05]: 	Setting xcodebuild_command to env NSUnbufferedIO=YES xcodebuild
+DEBUG [2022-09-08 10:52:45.05]: 	Setting skip_package_dependencies_resolution to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting disable_package_automatic_updates to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting use_system_scm to false
+DEBUG [2022-09-08 10:52:45.05]: 	Setting number_of_retries to 0
+DEBUG [2022-09-08 10:52:45.05]: 	Setting skip_build to false
+
++------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                                                                                                                                                                                                                                                                                                                                                                                                                            [0;32;49mSummary for scan 2.200.0[0m                                                                                                                                                                                                                                                                                                                                                                                                                            |
++------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| workspace                                      | /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/Bikemap.xcworkspace                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| fail_build                                     | true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| scheme                                         | Bikemap                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| output_types                                   | junit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| skip_detect_devices                            | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ensure_devices_found                           | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| force_quit_simulator                           | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| reset_simulator                                | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| disable_slide_to_type                          | true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| prelaunch_simulator                            | true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| reinstall_app                                  | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| app_identifier                                 | com.toursprung.bikemap                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| only_testing                                   | ["BikemapUITests/BMLoggedInUITests/testRatingDialog", "BikemapUITests/BMLoggedInUITests/testRideAlongRoute", "BikemapUITests/BMLoggedInUITests/testFilteringSorting", "BikemapUITests/BMLoggedInUITests/testCloseFinishScreen", "BikemapUITests/BMLoggedInUITests/testBikeComputerFreeRide", "BikemapUITests/BMLoggedInUITests/testDiscoverRouteNavigation", "BikemapUITests/BMLoggedInUITests/testGoToRideScreenAndFindBond", "BikemapUITests/BMLoggedInUITests/testPlanEditDeletePlannedRoute", "BikemapUITests/BMLoggedInUITests/testGoToMyRoutesAndCheckSubTabs", "BikemapUITests/BMAnonymousUITests/testLogInEmailAndLogout", "BikemapUITests/BMAnonymousUITests/testSearchAndFindVienna", "BikemapUITests/BMAnonymousUITests/testSignUpEmailAndLogout", "BikemapUITests/BMAnonymousUITests/testFacebookLoginAndLogout"] |
+| xctestrun                                      | build/DerivedData/Build/Products/Bikemap_iphonesimulator16.0-x86_64.xctestrun                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| clean                                          | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| open_report                                    | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| output_directory                               | /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapUITests-batch-2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| output_files                                   | report.junit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| buildlog_path                                  | ~/Library/Logs/scan                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| derived_data_path                              | build/DerivedData                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| should_zip_build_products                      | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| output_xctestrun                               | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| use_clang_report_name                          | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| disable_concurrent_testing                     | true                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| xcargs                                         | -UseNewBuildSystem=YES   -parallel-testing-enabled NO                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| slack_use_webhook_configured_username_and_icon | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| slack_username                                 | fastlane                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| slack_icon_url                                 | https://fastlane.tools/assets/img/fastlane_icon.png                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| skip_slack                                     | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| slack_only_on_failure                          | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| xcodebuild_command                             | env NSUnbufferedIO=YES xcodebuild                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| skip_package_dependencies_resolution           | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| disable_package_automatic_updates              | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| use_system_scm                                 | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| number_of_retries                              | 0                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| include_simulator_logs                         | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| skip_build                                     | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| xcode_path                                     | /Applications/Xcode-beta.app                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| result_bundle                                  | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| build_for_testing                              | false                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| devices                                        | ["iPhone 8"]                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
++------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+INFO [2022-09-08 10:52:45.07]: Starting scan #1 with 13 tests for batch #2.
+DEBUG [2022-09-08 10:52:45.07]: Fetching available simulator devices
+INFO [2022-09-08 10:52:45.48]: Disabling 'Slide to Type' iPhone 8
+INFO [2022-09-08 10:52:45.48]: [0;36;49m$ /usr/libexec/PlistBuddy -c "Add :KeyboardContinuousPathEnabled bool false" /Users/bikemap/Library/Developer/CoreSimulator/Devices/D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E/data/Library/Preferences/com.apple.keyboard.ContinuousPath.plist >/dev/null 2>&1[0m
+INFO [2022-09-08 10:52:45.50]: [0;36;49m$ set -o pipefail && env NSUnbufferedIO=YES xcodebuild -destination 'platform=iOS Simulator,id=D1A030C2-CA3F-4DBD-AD0E-3BCF0ED5340E' -derivedDataPath build/DerivedData -disable-concurrent-testing -xctestrun 'build/DerivedData/Build/Products/Bikemap_iphonesimulator16.0-x86_64.xctestrun' -UseNewBuildSystem=YES   -parallel-testing-enabled NO  -only-testing:BikemapUITests/BMLoggedInUITests/testRatingDialog -only-testing:BikemapUITests/BMLoggedInUITests/testRideAlongRoute -only-testing:BikemapUITests/BMLoggedInUITests/testFilteringSorting -only-testing:BikemapUITests/BMLoggedInUITests/testCloseFinishScreen -only-testing:BikemapUITests/BMLoggedInUITests/testBikeComputerFreeRide -only-testing:BikemapUITests/BMLoggedInUITests/testDiscoverRouteNavigation -only-testing:BikemapUITests/BMLoggedInUITests/testGoToRideScreenAndFindBond -only-testing:BikemapUITests/BMLoggedInUITests/testPlanEditDeletePlannedRoute -only-testing:BikemapUITests/BMLoggedInUITests/testGoToMyRoutesAndCheckSubTabs -only-testing:BikemapUITests/BMAnonymousUITests/testLogInEmailAndLogout -only-testing:BikemapUITests/BMAnonymousUITests/testSearchAndFindVienna -only-testing:BikemapUITests/BMAnonymousUITests/testSignUpEmailAndLogout -only-testing:BikemapUITests/BMAnonymousUITests/testFacebookLoginAndLogout test-without-building | tee '/Users/bikemap/Library/Logs/scan/Bikemap-Bikemap.log' | xcpretty  --report junit --output '/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapUITests-batch-2/report.junit' --report junit --output '/var/folders/k9/2frl09_n32vfltrncztxx4_m0000gn/T/junit_report20220908-35977-1faa837' [0m
+INFO [2022-09-08 10:52:45.50]: ▸ [0;35;49mLoading...[0m
+INFO [2022-09-08 10:53:05.09]: ▸ [0;35;49mSelected tests[0m
+INFO [2022-09-08 10:53:05.09]: ▸ [0;35;49mTest Suite [0m[0;35;49mBikemapUITests.xctest[0m[0;35;49m started[0m
+INFO [2022-09-08 10:53:05.09]: ▸ [0;35;49mBMLoggedInUITests[0m
+INFO [2022-09-08 10:53:38.15]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testGoToMyRoutesAndCheckSubTabs ([0m[0;35;49m33.061[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:54:49.51]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testRideAlongRoute ([0m[0;35;49m71.366[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:55:09.08]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testGoToRideScreenAndFindBond ([0m[0;35;49m19.566[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:55:51.86]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testBikeComputerFreeRide ([0m[0;35;49m42.782[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:56:32.67]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testRatingDialog ([0m[0;35;49m40.813[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:57:23.19]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testCloseFinishScreen ([0m[0;35;49m50.519[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:58:08.80]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testFilteringSorting ([0m[0;35;49m45.605[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 10:58:59.00]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testDiscoverRouteNavigation ([0m[0;35;49m50.198[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 11:00:11.62]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testPlanEditDeletePlannedRoute ([0m[0;35;49m72.627[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 11:00:11.64]: ▸ [0;35;49mBMAnonymousUITests[0m
+INFO [2022-09-08 11:01:11.75]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testSignUpEmailAndLogout ([0m[0;35;49m60.124[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 11:02:11.72]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testFacebookLoginAndLogout ([0m[0;35;49m59.975[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 11:02:59.42]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testLogInEmailAndLogout ([0m[0;35;49m47.699[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 11:03:23.26]: ▸ [0;35;49m    [0m[0;35;49m✓[0m[0;35;49m testSearchAndFindVienna ([0m[0;35;49m23.833[0m[0;35;49m seconds)[0m
+INFO [2022-09-08 11:03:23.27]: ▸ [0;35;49m[32;1m	 Executed 13 tests, with 0 failures (0 unexpected) in 618.167 (618.175) seconds[0m
+INFO [2022-09-08 11:03:23.27]: ▸ [0;35;49m[0m[0m
+INFO [2022-09-08 11:03:23.60]: ▸ [0;35;49m2022-09-08 11:03:23.604 xcodebuild[43499:21344118] [MT] IDETestOperationsObserverDebug: 632.038 elapsed -- Testing started completed.[0m
+INFO [2022-09-08 11:03:23.60]: ▸ [0;35;49m2022-09-08 11:03:23.604 xcodebuild[43499:21344118] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start[0m
+INFO [2022-09-08 11:03:23.60]: ▸ [0;35;49m2022-09-08 11:03:23.604 xcodebuild[43499:21344118] [MT] IDETestOperationsObserverDebug: 632.038 sec, +632.038 sec -- end[0m
+INFO [2022-09-08 11:03:23.96]: [0;35;49m▸[0m[0;35;49m [0m[0;35;49mTest execute[0m[0;35;49m Succeeded[0m
++--------------------+----+
+|      Test Results       |
++--------------------+----+
+| Number of tests    | 13 |
+| Number of failures | [0;32;49m0[0m  |
++--------------------+----+
+
+DEBUG [2022-09-08 11:03:23.98]: Batch #2 incrementing retry count to 1
+DEBUG [2022-09-08 11:03:23.98]: Scan passed the tests for batch #2
+INFO [2022-09-08 11:03:23.98]: [0;32;49m-----------------------------------------------------[0m
+INFO [2022-09-08 11:03:23.98]: [0;32;49mStep: set-simulator-location -c 51.510279 -0.138947[0m
+INFO [2022-09-08 11:03:23.98]: [0;32;49m-----------------------------------------------------[0m
+INFO [2022-09-08 11:03:23.98]: [0;36;49m$ set-simulator-location -c 51.510279 -0.138947[0m
+INFO [2022-09-08 11:03:24.22]: ▸ [0;35;49mSetting location to 51.510279 -0.138947[0m
+DEBUG [2022-09-08 11:03:24.22]: ReportCollator collating
+DEBUG [2022-09-08 11:03:24.22]: Collating results for all batches
+DEBUG [2022-09-08 11:03:24.22]: ReportCollator collating
+DEBUG [2022-09-08 11:03:24.22]: Copying junit report file /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapTests-batch-1/report.junit
+DEBUG [2022-09-08 11:03:24.22]: Collating results for all batches
+DEBUG [2022-09-08 11:03:24.22]: ReportCollator collating
+DEBUG [2022-09-08 11:03:24.22]: Copying junit report file /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapUITests-batch-2/report.junit
+DEBUG [2022-09-08 11:03:24.22]: Collating test targets's junit results
+DEBUG [2022-09-08 11:03:24.22]: Collating junit report files ["/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapTests/report.junit", "/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapUITests/report.junit"]
+DEBUG [2022-09-08 11:03:24.22]: collate_junit_reports with ["/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapTests/report.junit", "/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapUITests/report.junit"]
+DEBUG [2022-09-08 11:03:24.27]: > collating last report file /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapUITests/report.junit
+DEBUG [2022-09-08 11:03:24.28]: < collating last report file /Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/BikemapUITests/report.junit
+DEBUG [2022-09-08 11:03:24.29]: Results for each test run: [true, true]
+
++-------------------+---------------------------------------------------------------------------------------------------------+
+|                                                     [0;32;49mmulti_scan results[0m                                                      |
++-------------------+---------------------------------------------------------------------------------------------------------+
+| result            | true                                                                                                    |
+| total_tests       | 63                                                                                                      |
+| passing_testcount | 63                                                                                                      |
+| failed_testcount  | 0                                                                                                       |
+| failed_tests      | []                                                                                                      |
+| total_retry_count | 2                                                                                                       |
+| report_files      | ["/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/test_output/report.junit"] |
++-------------------+---------------------------------------------------------------------------------------------------------+
+
+INFO [2022-09-08 11:03:24.31]: [0;32;49mSuccessfully generated documentation at path '/Volumes/extra/jenkins/workspace/IOS-4984-route-planner-alignment/fastlane/README.md'[0m
+
++------+-----------------------------------------------+-------------+
+|                          [0;32;49mfastlane summary[0m                          |
++------+-----------------------------------------------+-------------+
+| Step | Action                                        | Time (in s) |
++------+-----------------------------------------------+-------------+
+| 1    | Verifying fastlane version                    | 0           |
+| 2    | default_platform                              | 0           |
+| 3    | set-simulator-location -c 51.510279 -0.138947 | 0           |
+| 4    | set-simulator-location -c 51.510279 -0.138947 | 0           |
+| 5    | multi_scan                                    | 1079        |
++------+-----------------------------------------------+-------------+
+
++-------------+--------------+----------------+
+|          [0;33;49mPlugin updates available[0m           |
++-------------+--------------+----------------+
+| Plugin      | Your Version | Latest Version |
++-------------+--------------+----------------+
+| test_center | [0;31;49m3.15.3[0m       | [0;32;49m3.19.1[0m         |
++-------------+--------------+----------------+
+INFO [2022-09-08 11:03:24.35]: To update all plugins, just run
+INFO [2022-09-08 11:03:24.35]: [0;36;49m$ bundle exec fastlane update_plugins[0m
+
+INFO [2022-09-08 11:03:24.35]: [0;32;49mfastlane.tools just saved you 18 minutes! 🎉[0m
+
+#######################################################################
+# fastlane 2.209.1 is available. You are on 2.200.0.
+# You should use the latest version.
+# Please update using `bundle update fastlane`.
+#######################################################################
+
+[0;32;49m2.209.1 Improvements[0m
+* [fastlane_core] install all Apple WWDR Intermediate Certificates (#20537) via Tony Li (@crazytonyli)
+* [Fastlane.swift] the word phrasing used has been standardized. (#20543) via Yusuke Arakawa (@nekolaboratory)
+* [spaceship] ignoring case sensitive when requesting SMS (#20436) via harrimaatta (@harrimaatta)
+
+[0;32;49m2.209.0 Improvements[0m
+* [deliver] fix typo caused by string concatenation (#20531) via Roger Oba (@rogerluan)
+* [frameit] faceook.design moved to design.facebook.com (#20513) via Guglielmo Faglioni (@guidev)
+* [match][sigh][cert] added checking hash of installed wwdr certificates (#20507) via grey442 (@grey442)
+* [action] adding no overwrite and local only options to the pod repo push command (#20455) via polmum (@polmum)
+* [core] fix unescaped \ (#20508) via Arthur Baars (@aibaars)
+* [action][tests] don't create keychain files in lazy manner (#20478) via Bartosz Nowak (@DuMaM)
+* [pilot] app_version and app_build should not be fetched from a local IPA or PKG when distribute_only is set (#20488) via Colin Tremblay (@tremblay)
+* [match] suppress null byte message (#20497) via Aaron Brager (@getaaron)
+
+[0;32;49m2.208.0 Improvements[0m
+* [spaceship] fix `fastlane init` and temporarily retrofitting `Spaceship::Tunes::Application.find` (#20480) via Josh Holtz (@joshdholtz)
+* [match][sigh] prefer default keychain during wwdr cert installation (#20448) via Bartosz Nowak (@DuMaM)
+* [match][sigh] fix access to certs installed by fastlane tools for productsign command for macOS (#20474) via Bartosz Nowak (@DuMaM)
+* [match] extract the certificate name from provisioning profiles (#20187) via Tejas Sharma (@tejassharma96)
+* [action][changelog_from_git_commits] fix description for documentation (#20430) via Mathijs Bernson (@mbernson)
+* [snapshot] use empty string to blank out operator name by default (#20429) via Zev Eisenberg (@ZevEisenberg)
+* [trainer] fix ERB.new() deprecation warnings (#20440) via Philipp Wallisch (@wallisch)
+* [match] fixes set up bugs when using GitLab Secure Files as a Match storage backend (#20452) via Darby Frey (@darbyfrey)
+
+[0;32;49mTo see all new releases, open https://github.com/fastlane/fastlane/releases[0m
+
+[0;32;49mPlease update using `bundle update fastlane`[0m
+[Pipeline] }
+[Pipeline] // stage
+[Pipeline] stage
+[Pipeline] { (Declarative: Post Actions)


### PR DESCRIPTION
### Description

The YML Parser Callisto is using doesn’t respect the order - it seems like it uses a Set internally instead of an Array. Additionally when two conflicting rules are applied it matches a random one which could lead to a failed build later in the pipeline. Correctly apply all silencing rules instead of the first matching one.

### Tasks

- [x] filter every rule from `config.yml` instead of first matching one