### PR TITLE
Add option to post html summary link

### DIFF
--- a/Callisto/FastlaneParser.swift
+++ b/Callisto/FastlaneParser.swift
@@ -167,7 +167,7 @@ private extension FastlaneParser {
     }
 
     func lineIsUnitTest(_ line: String) -> Bool {
-        let pattern = "✗"
+        let pattern = "✖"
         return self.check(line: line, withRegex: pattern)
     }
 

--- a/Callisto/PostGithubAction.swift
+++ b/Callisto/PostGithubAction.swift
@@ -31,6 +31,9 @@ final class PostToGithub: ParsableCommand {
     @Flag(help: "Delete previously postet comments from pull request")
     var deletePreviousComments: Bool = false
 
+    @Option(help: "URL to an external website hosting a HTML Report (XCTestHTMLReport)", completion: .file(), transform: URL.init(string:))
+    var htmlReport: URL?
+
     @Argument(help: "Location for .buildReport file", completion: .file(), transform: URL.init(fileURLWithPath:))
     var files: [URL] = []
 
@@ -134,12 +137,17 @@ final class GithubAction {
             for info in infos {
                 document.addComponent(Text(self.markdownText(from: info)))
             }
+            document.addComponent(EmptyLine())
+        }
+
+        if let htmlReport = self.command.htmlReport {
+            document.addComponent(Link("Detailed Test Report", url: htmlReport))
+            document.addComponent(EmptyLine())
         }
 
         if dependencies.hasElements {
             document.addComponent(Title("Dependencies", header: .h3))
             document.addComponent(EmptyLine())
-
 
             let outdated = dependencies.flatMap ({ $0.outdated })
             if outdated.hasElements {

--- a/Callisto/UnitTestMessage.swift
+++ b/Callisto/UnitTestMessage.swift
@@ -15,7 +15,7 @@ final class UnitTestMessage: Codable {
     let explanation: String
 
     init?(message: String) {
-        guard let xRange = (message.range(of: "✗")) else { return nil }
+        guard let xRange = (message.range(of: "✖")) else { return nil }
 
         let validMessage = message[xRange.lowerBound...]
         let components = validMessage.components(separatedBy: CharacterSet(charactersIn: ",-"))

--- a/Dependencies/MarkdownKit/Sources/MarkdownKit/Link.swift
+++ b/Dependencies/MarkdownKit/Sources/MarkdownKit/Link.swift
@@ -1,0 +1,25 @@
+//
+//  File.swift
+//  
+//
+//  Created by Patrick Kladek on 20.12.22.
+//
+
+import Foundation
+
+public struct Link: MarkdownConformable {
+
+    let title: String
+    let url: URL
+
+    public init(_ title: String, url: URL) {
+        self.title = title
+        self.url = url
+    }
+
+    public var lines: [String] {
+        let line = "[\(self.title)](\(self.url.absoluteString))"
+        return [line]
+    }
+}
+


### PR DESCRIPTION
### Description

When posting a comment to Github allow specifying a url to link to an external site containing a html test report.

### Tasks

- [x] Add flag with url to external site hosting a html file
- [x] update parser for xcbeautify

### Infos for Reviewer