### PR TITLE
Enhancement/retryed tests

### DIFF
--- a/Callisto/BuildInformation.swift
+++ b/Callisto/BuildInformation.swift
@@ -16,13 +16,13 @@ struct BuildInformation: Codable {
     let platform: String
     let errors: [CompilerMessage]
     let warnings: [CompilerMessage]
-    let unitTests: [UnitTestMessage]
+    let failedUnitTests: [UnitTestMessage]
     let config: Config
 
     static let empty = BuildInformation(platform: "",
                                         errors: [],
                                         warnings: [],
-                                        unitTests: [],
+                                        failedUnitTests: [],
                                         config: Config.empty)
 }
 
@@ -33,7 +33,7 @@ extension BuildInformation {
     }
 
     var isEmpty: Bool {
-        return self.errors.isEmpty && self.warnings.isEmpty && self.unitTests.isEmpty
+        return self.errors.isEmpty && self.warnings.isEmpty && self.failedUnitTests.isEmpty
     }
 
     var githubSummaryTitle: String {

--- a/Callisto/BuildInformation.swift
+++ b/Callisto/BuildInformation.swift
@@ -16,13 +16,15 @@ struct BuildInformation: Codable {
     let platform: String
     let errors: [CompilerMessage]
     let warnings: [CompilerMessage]
-    let failedUnitTests: [UnitTestMessage]
+    let brokenUnitTests: [UnitTestMessage]
+    let unreliableUnitTests: [UnitTestMessage]
     let config: Config
 
     static let empty = BuildInformation(platform: "",
                                         errors: [],
                                         warnings: [],
-                                        failedUnitTests: [],
+                                        brokenUnitTests: [],
+                                        unreliableUnitTests: [],
                                         config: Config.empty)
 }
 
@@ -33,7 +35,7 @@ extension BuildInformation {
     }
 
     var isEmpty: Bool {
-        return self.errors.isEmpty && self.warnings.isEmpty && self.failedUnitTests.isEmpty
+        return self.errors.isEmpty && self.warnings.isEmpty && self.brokenUnitTests.isEmpty
     }
 
     var githubSummaryTitle: String {

--- a/Callisto/Common.swift
+++ b/Callisto/Common.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2018 IdeasOnCanvas. All rights reserved.
 //
 
-import Foundation
 import Darwin // needed for exit()
+import Foundation
 
 
 enum ExitCodes: Int32 {

--- a/Callisto/Common.swift
+++ b/Callisto/Common.swift
@@ -29,6 +29,7 @@ enum ExitCodes: Int32 {
     case invalidBuildInformationFile = -16
     case invalidOutputFile = -17
     case containsWarnings = -18
+    case containsBrokenTests = -19
 }
 
 extension ExitCodes: CustomStringConvertible {
@@ -71,6 +72,8 @@ extension ExitCodes: CustomStringConvertible {
             return "invalid output file. Usage -output \"/path/to/file\""
         case .containsWarnings:
             return "This build contains warnings. Please resovle them."
+        case .containsBrokenTests:
+            return "This build contains repeatedly failing Tests. Please resovle them."
         }
     }
 }

--- a/Callisto/DependenciesAction.swift
+++ b/Callisto/DependenciesAction.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2021 IdeasOnCanvas. All rights reserved.
 //
 
-import Foundation
 import ArgumentParser
+import Foundation
 import MarkdownKit
 
 

--- a/Callisto/FailBuildAction.swift
+++ b/Callisto/FailBuildAction.swift
@@ -52,6 +52,12 @@ final class FailBuildAction: ParsableCommand {
             quit(.containsWarnings)
         }
 
+        let brokenTests = infos.flatMap { $0.brokenUnitTests }.uniqued()
+        guard brokenTests.isEmpty else {
+            brokenTests.forEach { LogError("Repeatedly failed: \($0.description)") }
+            quit(.containsBrokenTests)
+        }
+
         quit(.success)
     }
 }

--- a/Callisto/FailBuildAction.swift
+++ b/Callisto/FailBuildAction.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 Bikemap. All rights reserved.
 //
 
-import Foundation
 import ArgumentParser
+import Foundation
 
 
 // MARK: - FailBuildAction

--- a/Callisto/FastlaneParser.swift
+++ b/Callisto/FastlaneParser.swift
@@ -44,12 +44,12 @@ class FastlaneParser {
         self.buildSummary = BuildInformation(platform: self.parseSchemeFromFastlane(trimmedContent) ?? "",
                                              errors: self.parseBuildErrors(lines),
                                              warnings: self.parseAnalyzerWarnings(lines),
-                                             unitTests: self.parseUnitTestWarnings(lines),
+                                             failedUnitTests: self.parseUnitTestWarnings(lines),
                                              config: self.config)
 
         self.buildSummary.errors.forEach { LogError($0.description) }
         self.buildSummary.warnings.forEach { LogWarning($0.description) }
-        self.buildSummary.unitTests.forEach { LogWarning($0.description) }
+        self.buildSummary.failedUnitTests.forEach { LogWarning($0.description) }
         return self.parseExitStatusFromFastlane(trimmedContent)
     }
 }

--- a/Callisto/GitHubCommunicationController.swift
+++ b/Callisto/GitHubCommunicationController.swift
@@ -174,8 +174,8 @@ extension GitHubCommunicationController {
         do {
             let taskResult = try URLSession.shared.synchronousDataTask(with: self.defaultRequest(url: pullRequestUrl))
 
-            if taskResult.response?.statusCode != 200 {
-                NSLog("Error by sending Message!")
+            if let statusCode = taskResult.response?.statusCode, statusCode != 200 {
+                NSLog("Error URLRequest Status Code: \(statusCode)")
                 NSLog("%@", taskResult.response ?? "<nil>")
                 throw StatusCodeError.noResponse
             }

--- a/Callisto/PostGithubAction.swift
+++ b/Callisto/PostGithubAction.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 IdeasOnCanvas. All rights reserved.
 //
 
-import Foundation
 import ArgumentParser
+import Foundation
 import MarkdownKit
 
 

--- a/Callisto/PostGithubAction.swift
+++ b/Callisto/PostGithubAction.swift
@@ -213,12 +213,12 @@ private extension GithubAction {
 
         let commonErrors = infos[0].errors.filter { infos[1].errors.contains($0) }
         let commonWarnings = infos[0].warnings.filter { infos[1].warnings.contains($0) }
-        let commonUnitTests = infos[0].unitTests.filter { infos[1].unitTests.contains($0) }
+        let commonUnitTests = infos[0].failedUnitTests.filter { infos[1].failedUnitTests.contains($0) }
 
         return BuildInformation(platform: "Core",
                                 errors: commonErrors,
                                 warnings: commonWarnings,
-                                unitTests: commonUnitTests,
+                                failedUnitTests: commonUnitTests,
                                 config: .empty)
     }
 
@@ -229,7 +229,7 @@ private extension GithubAction {
             BuildInformation(platform: info.platform,
                              errors: info.errors.deleting(strip.errors),
                              warnings: info.warnings.deleting(strip.warnings),
-                             unitTests: info.unitTests.deleting(strip.unitTests),
+                             failedUnitTests: info.failedUnitTests.deleting(strip.failedUnitTests),
                              config: .empty)
         }
     }
@@ -245,7 +245,7 @@ private extension GithubAction {
                 LogWarning(warning.description)
             }
 
-            for unitTest in info.unitTests {
+            for unitTest in info.failedUnitTests {
                 LogWarning(unitTest.description)
             }
         }
@@ -254,7 +254,7 @@ private extension GithubAction {
     func markdownText(from info: BuildInformation) -> String {
         var string = info.githubSummaryTitle
 
-        if info.errors.isEmpty && info.warnings.isEmpty && info.unitTests.isEmpty {
+        if info.errors.isEmpty && info.warnings.isEmpty && info.failedUnitTests.isEmpty {
             string += "\n\n"
             string += "Well done 👍"
             return string
@@ -270,9 +270,9 @@ private extension GithubAction {
             string += info.warnings.map { ":warning: **\($0.file):\($0.line)**\n\($0.message)" }.joined(separator: "\n\n")
         }
 
-        if info.unitTests.hasElements {
+        if info.failedUnitTests.hasElements {
             string += "\n\n"
-            string += info.unitTests.map { ":large_blue_circle: `\($0.method)`\n\($0.assertType)\n\($0.explanation)" }.joined(separator: "\n\n")
+            string += info.failedUnitTests.map { ":large_blue_circle: `\($0.method)`\n\($0.assertType)\n\($0.explanation)" }.joined(separator: "\n\n")
         }
 
         string += "\n\n"

--- a/Callisto/PostGithubAction.swift
+++ b/Callisto/PostGithubAction.swift
@@ -274,7 +274,14 @@ private extension GithubAction {
 
         if info.brokenUnitTests.hasElements {
             string += "\n\n"
+            string += "### Broken Tests\n"
             string += info.brokenUnitTests.map { ":large_blue_circle: `\($0.method)`\n\($0.assertType ?? "")\n\($0.explanation ?? "")" }.joined(separator: "\n\n")
+        }
+
+        if info.unreliableUnitTests.hasElements {
+            string += "\n\n"
+            string += "### Unreliable Tests (passed after retry)\n"
+            string += info.unreliableUnitTests.map { ":large_blue_circle: `\($0.method)`\n\($0.assertType ?? "")\n\($0.explanation ?? "")" }.joined(separator: "\n\n")
         }
 
         string += "\n\n"

--- a/Callisto/PostGithubAction.swift
+++ b/Callisto/PostGithubAction.swift
@@ -256,10 +256,9 @@ private extension GithubAction {
     func markdownText(from info: BuildInformation) -> String {
         var string = info.githubSummaryTitle
 
-        if info.errors.isEmpty && info.warnings.isEmpty && info.brokenUnitTests.isEmpty {
+        if info.errors.isEmpty && info.warnings.isEmpty {
             string += "\n\n"
             string += "Well done 👍"
-            return string
         }
 
         if info.errors.hasElements {

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 IdeasOnCanvas. All rights reserved.
 //
 
-import Foundation
 import ArgumentParser
+import Foundation
 
 
 final class PostToSlack: ParsableCommand {

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -148,7 +148,7 @@ private extension PostSlackAction {
         message.add(attachment: self.makeSlackAttachment(warnings, type: .warning))
 
         // Unit Tests
-        let unitTests = infos.flatMap { $0.failedUnitTests }
+        let unitTests = infos.flatMap { $0.brokenUnitTests }
         let unitTestAttachment = self.makeSlackAttachment(unitTests, type: .warning)
         unitTestAttachment.colorHex = "0077FF"
         message.add(attachment: unitTestAttachment)

--- a/Callisto/PostSlackAction.swift
+++ b/Callisto/PostSlackAction.swift
@@ -148,7 +148,7 @@ private extension PostSlackAction {
         message.add(attachment: self.makeSlackAttachment(warnings, type: .warning))
 
         // Unit Tests
-        let unitTests = infos.flatMap { $0.unitTests }
+        let unitTests = infos.flatMap { $0.failedUnitTests }
         let unitTestAttachment = self.makeSlackAttachment(unitTests, type: .warning)
         unitTestAttachment.colorHex = "0077FF"
         message.add(attachment: unitTestAttachment)

--- a/Callisto/SlackCommunicationController.swift
+++ b/Callisto/SlackCommunicationController.swift
@@ -27,8 +27,8 @@ class SlackCommunicationController: NSObject {
         do {
             let (_, response) = try URLSession.shared.synchronousDataTask(with: urlRequest)
 
-            if response?.statusCode != 200 {
-                NSLog("Error by sending Message!")
+            if let statusCode = response?.statusCode, statusCode != 200 {
+                NSLog("Error URLRequest Status Code: \(statusCode)")
                 NSLog("%@", response ?? "<nil>")
             }
         } catch let error as NSError {

--- a/Callisto/SlackField.swift
+++ b/Callisto/SlackField.swift
@@ -26,7 +26,7 @@ class SlackField {
     }
 
     convenience init(message: UnitTestMessage) {
-        self.init(title: "\(message.method)", value: "\(message.assertType)\n\(message.explanation)")
+        self.init(title: "\(message.method)", value: "\(message.assertType ?? "")\n\(message.explanation ?? "")")
     }
 }
 

--- a/Callisto/SummariseAction.swift
+++ b/Callisto/SummariseAction.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 IdeasOnCanvas. All rights reserved.
 //
 
-import Foundation
 import ArgumentParser
+import Foundation
 import Yams
 
 

--- a/Dependencies/MarkdownKit/.swiftpm/xcode/xcshareddata/xcschemes/MarkdownKit.xcscheme
+++ b/Dependencies/MarkdownKit/.swiftpm/xcode/xcshareddata/xcschemes/MarkdownKit.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MarkdownKit"
+               BuildableName = "MarkdownKit"
+               BlueprintName = "MarkdownKit"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MarkdownKitTests"
+               BuildableName = "MarkdownKitTests"
+               BlueprintName = "MarkdownKitTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "MarkdownKit"
+            BuildableName = "MarkdownKit"
+            BlueprintName = "MarkdownKit"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
### Description

Xcode supports rerunning failed tests. Until now Callisto marked a test that failed and after rerun passed still as failed. This changes now, a test that passes at least once is considered passed. A test that failed all times is considered broken. Both of these cases will be posted to the GitHub comment.

### Tasks

- [x] correctly parse rerun tests
- [x] sort tests based on failed or broken
- [x] extend test summary GitHub comment

### Infos for Reviewer

Example comment

![Bildschirmfoto 2023-02-13 um 10 54 33](https://user-images.githubusercontent.com/18739004/218360095-dd63a592-f89b-4407-b731-954cffa67d6d.png)
